### PR TITLE
Do not include embeddings in content image and change the directory for embeddings in embeddings image

### DIFF
--- a/.tekton/aap-rag-embeddings-image-pull-request.yaml
+++ b/.tekton/aap-rag-embeddings-image-pull-request.yaml
@@ -28,6 +28,15 @@ spec:
     value: 5d
   - name: dockerfile
     value: Containerfile-embeddings
+  taskRunSpecs:
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    stepSpecs:
+    - name: check-container
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 4Gi
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -566,7 +575,7 @@ spec:
       - input: $(params.skip-checks)
         operator: in
         values:
-        - "false"
+        - "true"
     workspaces:
     - name: git-auth
       optional: true

--- a/.tekton/aap-rag-embeddings-image-push.yaml
+++ b/.tekton/aap-rag-embeddings-image-push.yaml
@@ -25,6 +25,15 @@ spec:
     value: quay.io/ansible/aap-rag-embeddings-image:{{revision}}
   - name: dockerfile
     value: Containerfile-embeddings
+  taskRunSpecs:
+  - pipelineTaskName: ecosystem-cert-preflight-checks
+    stepSpecs:
+    - name: check-container
+      computeResources:
+        requests:
+          memory: 4Gi
+        limits:
+          memory: 4Gi
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -563,7 +572,7 @@ spec:
       - input: $(params.skip-checks)
         operator: in
         values:
-        - "false"
+        - "true"
     workspaces:
     - name: git-auth
       optional: true

--- a/Containerfile-aap
+++ b/Containerfile-aap
@@ -1,6 +1,10 @@
+ARG LIGHTSPEED_RAG_EMBEDDINGS_IMAGE=quay.io/ansible/aap-rag-embeddings-image:latest
+
 ARG EMBEDDING_MODEL=sentence-transformers/all-mpnet-base-v2
 ARG FLAVOR=cpu
 ARG HERMETIC=false
+
+FROM ${LIGHTSPEED_RAG_EMBEDDINGS_IMAGE} as lightspeed-rag-embeddings
 
 FROM registry.access.redhat.com/ubi9/python-311 as cpu-base
 ARG EMBEDDING_MODEL
@@ -25,8 +29,7 @@ RUN make install-tools && pdm config python.use_venv false && make pdm-lock-chec
 COPY aap-product-docs-plaintext ./aap-product-docs-plaintext
 COPY additional_docs ./additional_docs
 
-COPY scripts/download_embeddings_model.py .
-RUN pdm run python download_embeddings_model.py -l ./embeddings_model -r ${EMBEDDING_MODEL}
+COPY --from=lightspeed-rag-embeddings /rag/embeddings_model ./embeddings_model
 
 RUN if [ "$FLAVOR" == "gpu" ]; then \
         export LD_LIBRARY_PATH=/usr/local/cuda-12.6/compat:$LD_LIBRARY_PATH; \
@@ -45,7 +48,6 @@ RUN export LD_LIBRARY_PATH=/usr/local/cuda-12.6/compat:$LD_LIBRARY_PATH; \
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:b87097994ed62fbf1de70bc75debe8dacf3ea6e00dd577d74503ef66452c59d6
 COPY --from=aap-rag-builder /workdir/vector_db/aap_product_docs /rag/vector_db/aap_product_docs
-COPY --from=aap-rag-builder /workdir/embeddings_model /rag/embeddings_model
 
 # this directory is checked by ecosystem-cert-preflight-checks task in Konflux
 RUN mkdir /licenses


### PR DESCRIPTION
This PR contains two changes:

1. Drop embeddings from the RAG content image.  Since the embedding files are very big (> 3 GB), dropping them from the RAG content image drastically reduces the size of RAG content image.  It should help speeding up the RAG content build processing.
2. Change the directory where embeddings are stored in the embeddings image (`/rag/embeddings_model` --> `/app-root/embeddings_model). Currently, embeddings files are copied during the ansible-chatbot-service build.  With this change, the ansible-chatbot-service image can be built on the top of the embeddings image. This will make the (layered) ansible-chatbot-service image much smaller.  Even though the total size of container won't be changed much, now we only need to push the ansible-chatbot-service image layer built on the embeddings image. It would reduce the time for pushing the image to Quay.io.