### PR TITLE
KB Article Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ from this repository, use the following steps.
      ./scripts/mimir-parser.py
     ```
 
+#### How to include Knowlege Base articles
+
+If you want to include Knowledge Base articles, which are stored
+under the `red_hat_content/solutions` folder in the Mimir archive,
+run the `mimir-parser.py` with the `--add-kb-articles` option, i.e.,
+```commandline
+./scripts/mimir-parser.py --add-kb-articles
+```
+The script extracts only the articles whose `[products]` metadata 
+contains `Red Hat Ansible Automation Platform`. The metadata is 
+defined in the beginning of each Knowledge Base markdown file.
+
 ### Build image
 ```commandline
 make build-image-aap


### PR DESCRIPTION
For [AAP-39677](https://issues.redhat.com/browse/AAP-39677)

KB Article Support is enabled by adding `--add-kb-articles` option to `mimir-parser.py`. It is NOT enabled by default.