### PR TITLE
Import torch before faiss

### DIFF
--- a/scripts/generate_embeddings-aap.py
+++ b/scripts/generate_embeddings-aap.py
@@ -9,9 +9,9 @@ from pathlib import Path
 from typing import Callable
 from typing import Dict
 
+import torch
 import faiss
 import requests
-import torch
 from llama_index.core import Settings
 from llama_index.core import SimpleDirectoryReader
 from llama_index.core import VectorStoreIndex


### PR DESCRIPTION
Import torch before faiss.  This seems to resolve the import issue:

```
  File "//test.py", line 14, in <module>
    import torch
  File "/usr/local/lib64/python3.11/site-packages/torch/__init__.py", line 405, in <module>
    from torch._C import *  # noqa: F403
    ^^^^^^^^^^^^^^^^^^^^^^
ImportError: /usr/local/cuda/lib64/libcusparse.so.12: undefined symbol: __nvJitLinkGetErrorLogSize_12_9, version libnvJitLink.so.12
```