### PR TITLE
AAP-67119: Add BYOK testathon sample additional content

### DIFF
--- a/byok/README.md
+++ b/byok/README.md
@@ -43,6 +43,36 @@ podman pull <rag-tool-image-gpu>:<tag>
 
 ---
 
+## Example Content Included in This Repository
+
+The `ansible-collection-docs/` directory in this repository contains a ready-to-use example
+that demonstrates two types of BYOK content working together:
+
+**1. Custom Ansible collection documentation** — `mycompany.infrastructure` (root level and subdirectories)
+
+A fictional enterprise collection with modules, lookup plugins, filter plugins, an inventory
+plugin, and user guides. Covers server provisioning, database management, network configuration,
+application deployment, and HashiCorp Vault integration.
+
+**2. Org-specific policy documentation** — `policies/` subdirectory
+
+MyCompany Corp internal governance documents that contain facts distinguishable from the default
+Ansible documentation. Used to validate that ALIA's responses change meaningfully when BYOK is
+active. Includes:
+
+| File | Content |
+|------|---------|
+| `mycompany-automation-standards.md` | Role naming (`mycompany_` prefix), Platform Team review workflow, CI requirements (`--mode stdout`), starter templates, secrets policy |
+| `mycompany-inventory-management-policy.md` | Group naming (`mycompany_<env>_<tier>`), required host variables, variable file structure, inventory source registration |
+| `mycompany-troubleshooting-guide.md` | Escalation paths (Team Lead → Platform Team → On-Call SRE), internal tools (`mycompany-job-tracer`, `mycompany-log-collector`), incident reporting |
+| `mycompany-playbook-patterns-and-role-conventions.md` | Role structure, required `meta/main.yml` fields, task tagging taxonomy, secrets lookup integration |
+
+These two content types complement each other: the collection docs provide plugin/module reference
+content, while the policy docs provide org-specific guidance — together they enable rich blended
+BYOK retrieval scenarios during testing.
+
+---
+
 ## Step 2 — Prepare Your Markdown Files
 
 Put your `.md` files in a local directory, e.g.:
@@ -50,7 +80,12 @@ Put your `.md` files in a local directory, e.g.:
 ```
 ./ansible-collection-docs/
   README.md
-  ...
+  modules/
+    create_server.md
+    ...
+  policies/
+    mycompany-automation-standards.md
+    ...
 ```
 
 ---
@@ -113,7 +148,7 @@ podman run --rm \
 | | `--output-image` | Path for the output `.tar` image archive (required) |
 | | `--image-name` | Repository name embedded in the image archive (default: `rag-content-output`) |
 | | `--image-tag` | Tag embedded in the image archive (default: `latest`) |
-| | `--no-include-model` | Exclude the embedding model from the output image (included by default) |
+| | `--exclude-model` | Exclude the embedding model from the output image (included by default) |
 
 > **Note:** `--userns=keep-id` is required so the container process runs as your host UID
 > and can write to the output directory.

--- a/byok/ansible-collection-docs/policies/mycompany-automation-standards.md
+++ b/byok/ansible-collection-docs/policies/mycompany-automation-standards.md
@@ -1,0 +1,137 @@
+---
+title: "MyCompany Corp Automation Standards"
+url: "https://internal.mycompany.example.com/wiki/automation/standards"
+---
+# MyCompany Corp Automation Standards
+
+This document defines the mandatory standards for all Ansible automation work at MyCompany Corp. All teams developing, maintaining, or deploying Ansible content must comply with these standards.
+
+---
+
+## Approved Collections
+
+The `mycompany.infrastructure` collection is the **approved standard** for infrastructure automation at MyCompany Corp. All infrastructure-related tasks (server provisioning, database management, network configuration, application deployment) must use the collection's modules before falling back to community content.
+
+Install the collection from the internal mirror:
+
+```bash
+ansible-galaxy collection install mycompany.infrastructure
+```
+
+Or pin the version in `requirements.yml`:
+
+```yaml
+collections:
+  - name: mycompany.infrastructure
+    version: ">=1.4.0"
+```
+
+Using the `mycompany.infrastructure` collection for infrastructure work is required. Using raw API calls or community equivalents where the collection provides the same functionality is not permitted in production playbooks.
+
+---
+
+## Role Naming Conventions
+
+All custom Ansible roles created at MyCompany Corp **must** use the `mycompany_` prefix. This prefix is required to distinguish internal roles from upstream community and Red Hat content, including the `mycompany.infrastructure` collection itself.
+
+### Required naming format
+
+```
+mycompany_<function>
+```
+
+Examples of correct role names:
+
+- `mycompany_webserver`
+- `mycompany_database_backup`
+- `mycompany_firewall_baseline`
+- `mycompany_monitoring_agent`
+
+Using the upstream convention (e.g., `ansible-webserver`, `redhat.rhel.firewall`) in MyCompany Corp repositories is prohibited and will cause the lint gate to fail during CI validation.
+
+---
+
+## Playbook Review and Approval Workflow
+
+All playbooks must be reviewed and approved by the **Platform Team** before any deployment to production environments.
+
+### Submission process
+
+1. Open a review request in the `#platform-ops` Slack channel using the pinned request template.
+2. Attach the playbook repository URL and the target environment.
+3. A Platform Team member will acknowledge within **1 business day** and complete the review within **3 business days**.
+
+### Escalation for delayed reviews
+
+If the Platform Team review has not been completed within **3 business days**, escalate directly to the **Automation Chapter Lead** at `automation-chapter-lead@mycompany.example.com`. Include the original Slack thread link and the date the review was requested.
+
+### Emergency and hotfix changes
+
+Emergency changes that cannot wait for the standard review process are permitted under the following conditions:
+
+- Written approval must be obtained from the **On-Call SRE Lead** before execution (via `#sre-oncall` Slack or direct message).
+- A post-incident review ticket must be created in `https://tickets.mycompany.internal` within **48 hours** of the change, tagged with `emergency-change`.
+- The standard Platform Team review must be completed retrospectively within **5 business days**.
+
+---
+
+## CI Pipeline Execution Requirements
+
+For all CI pipeline runs, automation must be executed using:
+
+```bash
+ansible-navigator run <playbook.yml> --mode stdout
+```
+
+The `--mode stdout` flag is a **non-negotiable org standard** for CI environments. Interactive and TUI modes (`--mode interactive`) are not permitted in any automated pipeline. This ensures that CI logs are captured as plain text and are parseable by the MyCompany log aggregation system.
+
+This requirement differs from the default `ansible-navigator` behavior and from the multiple execution modes described in the upstream Ansible documentation. At MyCompany Corp, `--mode stdout` is the only approved mode for CI.
+
+---
+
+## Starter Templates
+
+All new automation projects must be forked from the official MyCompany Corp starter templates. Starting from scratch or from community skeletons is not permitted for projects that will be deployed to production.
+
+Templates are maintained at:
+
+```
+https://gitlab.mycompany.internal/ansible/templates
+```
+
+Available templates:
+
+| Template | Purpose |
+| --- | --- |
+| `mycompany-playbook-starter` | Single-playbook automation projects |
+| `mycompany-role-starter` | Standalone Ansible roles |
+| `mycompany-collection-starter` | Ansible collections with multiple roles |
+| `mycompany-ee-starter` | Custom Execution Environment definitions |
+
+---
+
+## Secrets Management
+
+All secrets used in **production** playbook runs must be retrieved at runtime from **HashiCorp Vault** using the `mycompany.infrastructure.vault_secret` lookup plugin:
+
+```yaml
+db_password: "{{ lookup('mycompany.infrastructure.vault_secret', 'secret/prod/database/password') }}"
+```
+
+The `mycompany.infrastructure.vault_secret` plugin is part of the approved `mycompany.infrastructure` collection and automatically authenticates to the MyCompany Corp HashiCorp Vault cluster using the host's AppRole credentials. No manual token management is needed in playbooks.
+
+Storing secrets in Ansible Vault-encrypted YAML files (`ansible-vault encrypt`) is **not permitted** in production repositories. Ansible Vault may only be used in `dev` and `staging` environments.
+
+Contact the Platform Team in `#platform-ops` to request HashiCorp Vault access for a new automation project.
+
+---
+
+## Compliance and Enforcement
+
+These standards are enforced automatically:
+
+- **Lint gate**: `mycompany-role-linter` runs on every merge request and will block merges that violate naming conventions or are missing required metadata.
+- **CI validation**: The MyCompany CI validator checks for correct `ansible-navigator` flags and rejects pipelines that use non-approved execution modes.
+- **Quarterly audits**: The Platform Team audits all active automation repositories for compliance each quarter.
+
+Repeated violations after two warnings will result in the project being locked from production deployments until compliance is restored.

--- a/byok/ansible-collection-docs/policies/mycompany-inventory-management-policy.md
+++ b/byok/ansible-collection-docs/policies/mycompany-inventory-management-policy.md
@@ -1,0 +1,136 @@
+---
+title: "MyCompany Corp Inventory Management Policy"
+url: "https://internal.mycompany.example.com/wiki/automation/inventory-policy"
+---
+# MyCompany Corp Inventory Management Policy
+
+This document defines the mandatory conventions for structuring, naming, and maintaining Ansible inventories at MyCompany Corp. All automation teams must follow these conventions to ensure consistent pipeline behavior and to pass MyCompany CI validation.
+
+---
+
+## Inventory Group Naming
+
+All inventory groups must follow a strict naming pattern that encodes the environment and infrastructure tier:
+
+```
+mycompany_<env>_<tier>
+```
+
+### Environment values
+
+The `<env>` segment must be one of: `dev`, `staging`, `prod`.
+
+### Tier values
+
+Common tier values include `web`, `db`, `cache`, `worker`, `lb` (load balancer), and `mgmt` (management). New tiers must be approved by the Platform Team before use.
+
+### Correct group name examples
+
+- `mycompany_prod_web` — production web servers
+- `mycompany_staging_db` — staging database servers
+- `mycompany_dev_cache` — development cache nodes
+- `mycompany_prod_lb` — production load balancers
+- `mycompany_prod_worker` — production async worker nodes
+
+### Incorrect group name examples (will fail CI validation)
+
+- `production_web` — missing `mycompany_` prefix
+- `mycompany_web_prod` — env and tier are reversed
+- `webservers` — missing prefix and env segment
+
+---
+
+## Required Host Variables
+
+### The `mycompany_env` variable
+
+The variable `mycompany_env` is **mandatory** on every managed host. It must be set to exactly one of: `dev`, `staging`, `prod`.
+
+Playbook runs will fail the pre-flight validation step if any host in the targeted inventory is missing this variable. There are no exceptions.
+
+Set `mycompany_env` in `host_vars/<hostname>/main.yml`:
+
+```yaml
+mycompany_env: prod
+```
+
+Do not rely on group membership to infer the environment — the variable must be explicit on each host.
+
+### Additional required variables
+
+| Variable | Required on | Allowed values | Description |
+| --- | --- | --- | --- |
+| `mycompany_env` | All hosts | `dev`, `staging`, `prod` | Deployment environment |
+| `mycompany_owner_team` | All hosts | Any valid team slug | Team responsible for this host |
+| `mycompany_managed` | All hosts | `true`, `false` | Whether MyCompany automation manages this host |
+
+---
+
+## Variable File Structure
+
+### Host-specific variables
+
+All host-specific variables must be defined in:
+
+```
+host_vars/<hostname>/main.yml
+```
+
+Defining host-level variable overrides inside `group_vars` files is **prohibited**. This rule prevents hidden precedence bugs and makes host configuration auditable.
+
+Additional host variable files (e.g., `host_vars/<hostname>/vault.yml` for dev/staging secrets) are permitted alongside `main.yml`.
+
+### Group variables
+
+Group-level variables belong in:
+
+```
+group_vars/<group_name>/main.yml
+```
+
+Each group must have its own directory; single-file `group_vars/<group_name>.yml` format is deprecated and will be rejected by the MyCompany CI validator after 2026-Q3.
+
+---
+
+## Inventory Source Registration
+
+### Dynamic inventory sources
+
+Before a dynamic inventory source (e.g., an AWX inventory plugin, a custom script, or a cloud provider plugin) can be used in any MyCompany pipeline, it must be registered in the **MyCompany Inventory Registry**:
+
+```
+https://inventory.mycompany.internal
+```
+
+Unregistered dynamic sources will be blocked at the pipeline level. Submit a registration request via the Registry web UI — approval from the Platform Team is required and typically completes within 2 business days.
+
+The `mycompany.infrastructure.dynamic_cloud` inventory plugin is pre-approved and does not require registration.
+
+### Static inventory files
+
+Static inventory files must use one of the following extensions to be recognized by the MyCompany CI validator:
+
+- `.mycompany.ini` — INI-format static inventories
+- `.mycompany.yml` — YAML-format static inventories
+
+Files with standard extensions (`.ini`, `.yml`, `.yaml`) will not be automatically discovered by MyCompany tooling and will produce a warning in CI.
+
+---
+
+## Inventory Validation
+
+The `mycompany-inventory-validator` tool runs as part of every CI pipeline and checks:
+
+1. All group names match the `mycompany_<env>_<tier>` pattern
+2. All hosts define `mycompany_env` with an approved value
+3. All hosts define `mycompany_owner_team`
+4. No host-level overrides exist inside `group_vars`
+5. Dynamic sources are registered in the MyCompany Inventory Registry (or are `mycompany.infrastructure.dynamic_cloud`)
+
+To run the validator locally before pushing:
+
+```bash
+mycompany-inventory-validator --inventory-path ./inventory/
+```
+
+Failures in inventory validation block the pipeline and must be resolved before merge.

--- a/byok/ansible-collection-docs/policies/mycompany-playbook-patterns-and-role-conventions.md
+++ b/byok/ansible-collection-docs/policies/mycompany-playbook-patterns-and-role-conventions.md
@@ -1,0 +1,214 @@
+---
+title: "MyCompany Corp Playbook Patterns and Role Naming Conventions"
+url: "https://internal.mycompany.example.com/wiki/automation/playbook-patterns"
+---
+# MyCompany Corp Playbook Patterns and Role Naming Conventions
+
+This document describes the required structure and patterns for Ansible playbooks and roles at MyCompany Corp. Compliance with these conventions is enforced by the `mycompany-role-linter` CI tool on every merge request.
+
+---
+
+## Role Naming
+
+All Ansible roles developed at MyCompany Corp must follow the `mycompany_<function>` naming pattern.
+
+### Correct examples
+
+- `mycompany_webserver`
+- `mycompany_database_backup`
+- `mycompany_monitoring_agent`
+- `mycompany_firewall_baseline`
+
+### Why this differs from upstream
+
+Upstream Ansible community conventions and Red Hat Certified Content use naming patterns like `redhat.<collection>.<role>` or `ansible-<function>`. At MyCompany Corp, the `mycompany_` flat prefix is used for all standalone roles to:
+
+- Clearly distinguish internal roles from community content at a glance
+- Avoid namespace collisions with modules and plugins in the `mycompany.infrastructure` collection
+- Ensure consistent behavior from `mycompany-role-linter` across all repositories
+
+Using upstream naming patterns (e.g., `ansible-webserver`, `redhat.rhel.webserver`) in MyCompany Corp role repositories will fail the `mycompany-role-linter` gate and block the merge request.
+
+---
+
+## Required Role Directory Structure
+
+Every MyCompany Corp role must include the following directories:
+
+```
+mycompany_<function>/
+├── tasks/
+│   └── main.yml
+├── handlers/
+│   └── main.yml
+├── defaults/
+│   └── main.yml
+├── vars/
+│   └── main.yml
+├── templates/
+├── files/
+└── meta/
+    └── main.yml
+```
+
+The `meta/` directory and its `main.yml` are **required**. Merge requests for roles missing `meta/` will be blocked automatically by `mycompany-role-linter`.
+
+---
+
+## Required Role Metadata (`meta/main.yml`)
+
+Every role's `meta/main.yml` must include the following fields:
+
+```yaml
+galaxy_info:
+  author: mycompany-platform-team
+  company: "MyCompany Corp"
+  description: "<brief description of what this role does>"
+  license: "Proprietary"
+  min_ansible_version: "2.14"
+```
+
+The `author` field must be exactly `mycompany-platform-team` and the `company` field must be exactly `"MyCompany Corp"`. `mycompany-role-linter` validates both fields on every CI run.
+
+Additional metadata fields (e.g., `platforms`, `dependencies`) are permitted but optional.
+
+---
+
+## Playbook Structure Requirements
+
+### Explicit fact gathering
+
+All MyCompany Corp playbooks must declare `gather_facts: true` explicitly. Do not rely on the Ansible default behavior:
+
+```yaml
+- name: Configure web servers
+  hosts: mycompany_prod_web
+  gather_facts: true
+  become: true
+  collections:
+    - mycompany.infrastructure
+  roles:
+    - mycompany_webserver
+```
+
+Including `collections: [mycompany.infrastructure]` at the play level is required whenever any module, lookup, filter, or inventory plugin from the collection is used. This is required because some MyCompany environments have modified `ansible.cfg` defaults and the explicit declaration ensures consistent behavior across all CI and production environments.
+
+### Task tagging
+
+All tasks in MyCompany Corp playbooks must be tagged using the MyCompany tag taxonomy. The three required top-level tags are:
+
+| Tag | When to apply |
+| --- | --- |
+| `mycompany_install` | Tasks that install packages, binaries, or files |
+| `mycompany_configure` | Tasks that write configuration files or modify system settings |
+| `mycompany_validate` | Tasks that check state, run tests, or assert expected conditions |
+
+Example:
+
+```yaml
+- name: Install nginx package
+  ansible.builtin.package:
+    name: nginx
+    state: present
+  tags:
+    - mycompany_install
+
+- name: Deploy nginx configuration
+  ansible.builtin.template:
+    src: nginx.conf.j2
+    dest: /etc/nginx/nginx.conf
+  tags:
+    - mycompany_configure
+
+- name: Verify nginx is listening on port 80
+  ansible.builtin.wait_for:
+    port: 80
+    timeout: 30
+  tags:
+    - mycompany_validate
+```
+
+Tasks without at least one MyCompany tag will produce a warning from `mycompany-role-linter` and will fail in strict mode (enabled for all production pipelines).
+
+---
+
+## Secrets Handling
+
+### Production environments
+
+In production, all secrets must be retrieved at runtime from **HashiCorp Vault** using the `mycompany.infrastructure.vault_secret` lookup plugin, which is part of the approved `mycompany.infrastructure` collection:
+
+```yaml
+- name: Configure database connection
+  ansible.builtin.template:
+    src: db.conf.j2
+    dest: /etc/app/db.conf
+  vars:
+    db_password: "{{ lookup('mycompany.infrastructure.vault_secret', 'secret/prod/database/password') }}"
+    db_user: "{{ lookup('mycompany.infrastructure.vault_secret', 'secret/prod/database/username') }}"
+```
+
+The `mycompany.infrastructure.vault_secret` plugin automatically authenticates to the MyCompany Corp HashiCorp Vault cluster using the host's AppRole credentials. No manual token management is needed in playbooks. For full plugin documentation, see the collection's [vault_secret lookup guide](../lookup/vault_secret.md).
+
+### Development and staging environments
+
+For `dev` and `staging` environments only, `ansible.builtin.vault_encrypted_file` references are permitted as a convenience during development:
+
+```yaml
+vars_files:
+  - vars/vault.yml  # ansible-vault encrypted, dev/staging only
+```
+
+**Never commit Ansible Vault-encrypted files to repositories that target production.** The MyCompany CI validator checks `mycompany_env` and will reject pipelines that reference `vars_files` with vault-encrypted content when the target environment is `prod`.
+
+### Secret naming in Vault
+
+Secrets in HashiCorp Vault follow the path convention:
+
+```
+secret/<env>/<service>/<key>
+```
+
+Examples:
+- `secret/prod/database/password`
+- `secret/staging/redis/auth_token`
+- `secret/prod/smtp/api_key`
+
+---
+
+## Using mycompany.infrastructure Modules in Playbooks
+
+When tasks require infrastructure operations covered by the `mycompany.infrastructure` collection (server provisioning, database management, network configuration, application deployment), use the collection modules directly:
+
+```yaml
+- name: Provision application server
+  mycompany.infrastructure.create_server:
+    name: "app-{{ mycompany_env }}-01"
+    provider: aws
+    region: eu-west-1
+    instance_type: t3.medium
+    tags:
+      env: "{{ mycompany_env }}"
+      team: "{{ mycompany_owner_team }}"
+  tags:
+    - mycompany_install
+```
+
+Note how `mycompany_env` and `mycompany_owner_team` (required host variables from the Inventory Policy) are used to drive module parameters. This ensures consistent tagging across all provisioned resources.
+
+---
+
+## Playbook and Role Development Workflow
+
+1. Fork the appropriate starter template from `https://gitlab.mycompany.internal/ansible/templates`
+2. Name your role following the `mycompany_<function>` convention
+3. Populate `meta/main.yml` with the required fields before writing any tasks
+4. Apply MyCompany tag taxonomy (`mycompany_install`, `mycompany_configure`, `mycompany_validate`) to all tasks
+5. Use `mycompany.infrastructure.vault_secret` for any secrets required by the role
+6. Run `mycompany-role-linter` locally before opening a merge request:
+
+```bash
+mycompany-role-linter --role-path ./mycompany_<function>/
+```
+
+7. Submit the merge request and request Platform Team review via `#platform-ops` Slack

--- a/byok/ansible-collection-docs/policies/mycompany-troubleshooting-guide.md
+++ b/byok/ansible-collection-docs/policies/mycompany-troubleshooting-guide.md
@@ -1,0 +1,142 @@
+---
+title: "MyCompany Corp Automation Troubleshooting Guide"
+url: "https://internal.mycompany.example.com/wiki/automation/troubleshooting"
+---
+# MyCompany Corp Automation Troubleshooting Guide
+
+This guide covers how to diagnose failed Ansible automation jobs at MyCompany Corp, which internal tools to use, and how to escalate when self-service troubleshooting is not sufficient.
+
+---
+
+## Internal Debugging Tools
+
+### mycompany-job-tracer
+
+The primary tool for diagnosing Ansible job failures is **`mycompany-job-tracer`**, a web-based UI maintained by the Platform Team.
+
+**Access:** `https://tools.mycompany.internal/job-tracer`
+
+`mycompany-job-tracer` ingests Ansible stdout logs and provides:
+
+- Task-level timing breakdown (identify which tasks are slow or hung)
+- Variable snapshot at the point of failure (see what values were in scope)
+- Diff output for tasks that report changes
+- Side-by-side comparison between two job runs
+- Direct link to the relevant playbook line in GitLab
+
+To use `mycompany-job-tracer`, you need the **job ID** from the AAP job detail page. Paste the job ID into the search box on the tracer home page.
+
+### mycompany-log-collector
+
+Before escalating any automation issue to the Platform Team or SRE, run the **`mycompany-log-collector`** script to bundle the relevant diagnostics:
+
+```bash
+/usr/local/bin/mycompany-log-collector --job-id <JOB_ID>
+```
+
+This script collects:
+
+- Full Ansible stdout for the job
+- Gathered facts for all targeted hosts
+- The last 50 task outputs with return values
+- The inventory and variable files used
+- Any callback plugin output
+
+The output is a `.tar.gz` support bundle saved to `/tmp/mycompany-support-<JOB_ID>.tar.gz`. Attach this bundle to your escalation ticket or Slack message.
+
+### Additional diagnostic commands
+
+For targeted host-level investigation, the following commands are available on all MyCompany-managed hosts:
+
+```bash
+# Check Ansible connection and fact gathering
+ansible <hostname> -m setup -i inventory/ --ask-become-pass
+
+# Test connectivity and privilege escalation
+ansible <hostname> -m ping -i inventory/ --become
+
+# Replay the last job in check mode (dry run)
+ansible-navigator run <playbook.yml> --mode stdout --check
+
+# Test mycompany.infrastructure collection connectivity
+ansible <hostname> -m mycompany.infrastructure.create_server --check -i inventory/
+```
+
+---
+
+## Escalation Paths
+
+### Standard escalation path for production failures
+
+When an automation job fails in production, follow this escalation sequence:
+
+1. **Team Lead** — notify your direct team lead immediately. They must be aware of all production failures.
+2. **Platform Team** — if the issue cannot be resolved within 30 minutes, post in `#platform-ops` Slack with the job ID and a brief description. Platform Team engineers are available during business hours (09:00–18:00 CET).
+3. **On-Call SRE** — if the failure is causing or at risk of causing production downtime, page the On-Call SRE via the `#sre-oncall` Slack channel. For urgent pages, use PagerDuty: `https://mycompany.pagerduty.com`.
+
+### Who to contact when Platform Team review is slow
+
+If you submitted a troubleshooting request or review to the Platform Team via `#platform-ops` and have not received a response within **3 business days**, escalate to the **Automation Chapter Lead** at `automation-chapter-lead@mycompany.example.com`.
+
+Include in your escalation email:
+- The original Slack thread link
+- The date you submitted the request
+- A brief summary of the issue and business impact
+
+### Non-critical failures
+
+For non-critical automation failures that are not causing production downtime:
+
+1. Attempt self-service diagnosis using `mycompany-job-tracer` and `mycompany-log-collector`.
+2. If unresolved after **two self-service attempts**, file a ticket at `https://tickets.mycompany.internal` using the template **"Automation Failure — Needs Triage"**.
+3. Attach the `mycompany-log-collector` support bundle to the ticket.
+4. Set the ticket label to `automation-incident` and assign it to the `platform-team` group.
+
+---
+
+## Production Incident Reporting
+
+Any automation failure that causes or contributes to **production downtime** must be reported immediately, regardless of the time of day:
+
+1. Post in `#production-incidents` Slack with:
+   - A one-line summary of the failure
+   - The affected service or hosts
+   - The job ID (if applicable)
+   - Current status (ongoing / mitigated / resolved)
+
+2. Create an incident ticket at `https://tickets.mycompany.internal` with:
+   - Label: `automation-incident`
+   - Label: `production-impact`
+   - Severity: set according to the MyCompany Incident Severity Guide (linked in the ticket template)
+
+3. Attach the `mycompany-log-collector` support bundle once collected.
+
+Platform Team and SRE On-Call monitor `#production-incidents` continuously during business hours and are paged for new messages outside of business hours.
+
+---
+
+## Emergency Change Exception Process
+
+If a production automation failure requires an emergency fix that cannot wait for the standard review process, the exception process is:
+
+1. Obtain **written approval from the On-Call SRE Lead** via `#sre-oncall` Slack before making any emergency change.
+2. Execute the minimum change necessary to restore service.
+3. Post a summary of the change in `#production-incidents` immediately after execution.
+4. Create a post-incident review ticket at `https://tickets.mycompany.internal` within **48 hours**, tagged with `emergency-change` and `post-incident-review`.
+5. Complete a retrospective standard Platform Team review within **5 business days**.
+
+Emergency changes made without On-Call SRE Lead approval are policy violations and will be reviewed by the Automation Chapter Lead.
+
+---
+
+## Common Failure Patterns and Quick Fixes
+
+| Symptom | Likely cause | First action |
+| --- | --- | --- |
+| `mycompany_env` variable missing | Host not fully onboarded | Add `mycompany_env` to `host_vars/<hostname>/main.yml` |
+| `mycompany.infrastructure.vault_secret` lookup fails | HashiCorp Vault token expired | Re-authenticate: `vault login -method=ldap username=<you>` |
+| Group name fails CI validation | Group name doesn't match `mycompany_<env>_<tier>` | Rename the group in your inventory |
+| Inventory source rejected | Dynamic source not registered | Register at `https://inventory.mycompany.internal` |
+| `mycompany-role-linter` fails | Missing `meta/main.yml` or wrong author field | Add or fix `meta/main.yml` (see Playbook Patterns guide) |
+| ansible-navigator CI failure | Using `--mode interactive` in pipeline | Change to `--mode stdout` in your CI configuration |
+| `mycompany.infrastructure` module fails | Collection version mismatch | Run `ansible-galaxy collection install mycompany.infrastructure --upgrade` |


### PR DESCRIPTION
# Ticket
[AAP-67119](https://redhat.atlassian.net/browse/AAP-67119)

# Summary
Add four org-specific policy documents to ansible-collection-docs/policies/ as example BYOK content for the AAP-67119 testathon. These docs contain verifiable facts distinguishable from default Ansible docs, enabling testers to confirm BYOK RAG image influence on ALIA responses.

# Changes
- Added `mycompany-automation-standards.md` (role naming, CI requirements, review workflow)
- Added `mycompany-inventory-management-policy.md` (group naming, host variables)
- Added `mycompany-troubleshooting-guide.md` (escalation paths, internal tools)
- Added `mycompany-playbook-patterns-and-role-conventions.md` (role structure, secrets)
- Updated `README.md` to document the two-layer content structure (collection docs and policy docs) now included as a ready-to-use example in this repository.
- The naming aligns with the existing `mycompany.infrastructure` collection docs already in this repo, enabling blended-context test scenario.
