### PR TITLE
AAP-71672: Add MyCompany Corp org policy docs for BYOK testathon

### DIFF
--- a/byok/ansible-collection-docs/SUMMARY.md
+++ b/byok/ansible-collection-docs/SUMMARY.md
@@ -26,9 +26,14 @@ ansible-collection-docs-md/
 │   └── infrastructure_filters.md     ← all 3 filters in one file (to_cidr, parse_json_string, extract_tags)
 ├── inventory/
 │   └── dynamic_cloud.md
-└── guides/
-    ├── authentication.md
-    └── migration_1x_to_2x.md
+├── guides/
+│   ├── authentication.md
+│   └── migration_1x_to_2x.md
+└── policies/
+    ├── naming_conventions.md          ← mycompany_ role prefix, mycompany_<env>_<tier> inventory groups
+    ├── playbook_review.md             ← Platform Team approval, #platform-ops, 3-day SLA, emergency changes
+    ├── troubleshooting_escalation.md  ← mycompany-job-tracer, escalation path (Team Lead → Platform Team → On-Call SRE)
+    └── ci_automation_policy.md        ← ansible-navigator run --mode stdout mandate (interactive mode prohibited)
 ```
 
 ---
@@ -71,6 +76,15 @@ ansible-collection-docs-md/
 |---|---|
 | `authentication.md` | Gateway token, IAM, Vault integration, and ansible.cfg configuration |
 | `migration_1x_to_2x.md` | Breaking changes, removed parameters, and upgrade steps |
+
+### Organizational Policies
+
+| Policy | Description |
+|---|---|
+| `policies/naming_conventions.md` | Mandatory `mycompany_` role prefix and `mycompany_<env>_<tier>` inventory group pattern |
+| `policies/playbook_review.md` | Platform Team approval via `#platform-ops`, 3-day SLA, emergency change process |
+| `policies/troubleshooting_escalation.md` | `mycompany-job-tracer` usage and Team Lead → Platform Team → On-Call SRE escalation path |
+| `policies/ci_automation_policy.md` | `ansible-navigator run --mode stdout` mandate; `--mode interactive` and `--mode tui` prohibited in CI |
 
 ---
 

--- a/byok/ansible-collection-docs/policies/ci_automation_policy.md
+++ b/byok/ansible-collection-docs/policies/ci_automation_policy.md
@@ -1,0 +1,169 @@
+---
+title: "MyCompany CI Automation Policy"
+url: "https://github.com/ansible/aap-rag-content/blob/main/byok/ansible-collection-docs/policies/ci_automation_policy.md"
+---
+# MyCompany CI Automation Policy
+
+This document defines the mandatory standards for running Ansible automation in Continuous Integration (CI) pipelines at MyCompany Corp. All teams integrating Ansible playbook execution into CI/CD workflows must comply with this policy.
+
+---
+
+## Required Command for CI Pipelines
+
+**The only permitted way to run Ansible automation in a MyCompany CI pipeline is:**
+
+```bash
+ansible-navigator run <playbook.yml> --mode stdout
+```
+
+The `--mode stdout` flag is **mandatory** in all CI contexts. No exceptions.
+
+---
+
+## Mode Policy
+
+| Mode | Permitted in CI? | Notes |
+|------|-----------------|-------|
+| `--mode stdout` | **YES — required** | The only approved mode for CI pipelines |
+| `--mode interactive` | **NO — prohibited** | Requires a TTY; breaks non-interactive CI runners |
+| `--mode tui` | **NO — prohibited** | Requires a TTY; incompatible with pipeline log capture |
+
+### Why `--mode stdout` is Mandatory
+
+CI pipeline runners (GitLab CI, GitHub Actions, Jenkins, Tekton) run in non-interactive, headless environments. They do not provide a TTY. The `--mode interactive` and `--mode tui` modes require a real terminal and will either hang, crash, or produce garbled output when run in a CI context.
+
+`--mode stdout` writes all task output directly to standard output in plain text, which:
+- Is captured correctly by CI log aggregators
+- Allows log parsing for pass/fail detection
+- Is compatible with all CI runners used at MyCompany
+
+**Running `--mode interactive` in CI will cause the pipeline job to hang indefinitely and must never be used.**
+
+---
+
+## Full CI Command Reference
+
+A complete CI-compliant `ansible-navigator run` command looks like this:
+
+```bash
+ansible-navigator run site.yml \
+  --mode stdout \
+  --eei quay.mycompany.internal/ee/mycompany-ee:latest \
+  --pae false \
+  --pp missing
+```
+
+### Required Flags
+
+| Flag | Value | Reason |
+|------|-------|--------|
+| `--mode stdout` | `stdout` | **Mandatory** — non-interactive output mode |
+| `--eei` | `quay.mycompany.internal/ee/mycompany-ee:latest` | Use the approved MyCompany execution environment |
+| `--pae false` | `false` | Disable pull-after-everything to use cached images |
+| `--pp missing` | `missing` | Pull the EE image only if not already present |
+
+### Optional Flags
+
+| Flag | Description |
+|------|-------------|
+| `--extra-vars @vars.yml` | Pass additional variables from a file |
+| `--limit mycompany_staging_*` | Restrict execution to a specific inventory group |
+| `-v` or `-vv` | Increase verbosity for debugging |
+
+---
+
+## Execution Environment (EE)
+
+All CI runs must use an approved MyCompany execution environment image. The standard EE is:
+
+```
+quay.mycompany.internal/ee/mycompany-ee:latest
+```
+
+This image includes:
+- `ansible-core` pinned to the approved version
+- `mycompany.infrastructure` collection pre-installed
+- `mycompany-job-tracer` CLI
+- All required Python dependencies
+
+Using a non-approved EE or a plain `ansible-playbook` invocation instead of `ansible-navigator` is **not permitted in CI**.
+
+---
+
+## Settings File
+
+Each project should include an `ansible-navigator.yml` settings file in the project root that enforces the CI defaults:
+
+```yaml
+ansible-navigator:
+  mode: stdout
+  execution-environment:
+    image: quay.mycompany.internal/ee/mycompany-ee:latest
+    pull:
+      policy: missing
+  playbook-artifact:
+    enable: false
+```
+
+With this file in place, running `ansible-navigator run site.yml` in CI will automatically use `--mode stdout` without requiring the flag to be specified on the command line. However, the `--mode stdout` flag must still be present in pipeline configuration for clarity and auditability.
+
+---
+
+## Secrets in CI Pipelines
+
+Never pass secrets as plain environment variables or inline YAML in CI pipelines. Use the `mycompany.infrastructure.vault_secret` lookup plugin to retrieve secrets at runtime from HashiCorp Vault.
+
+The CI runner's service account has read access to the following Vault paths:
+- `secret/ci/<project_name>/credentials`
+- `secret/ci/<project_name>/api_keys`
+
+See [vault_secret lookup plugin documentation](../lookup/vault_secret.md) for usage.
+
+---
+
+## Linting Before `ansible-navigator run`
+
+The CI pipeline must run linting checks before executing any playbook:
+
+```yaml
+# GitLab CI example
+lint:
+  script:
+    - ansible-lint --profile production
+    - yamllint .
+  before_script:
+    - ansible-galaxy collection install -r requirements.yml
+
+run:
+  script:
+    - ansible-navigator run site.yml --mode stdout --eei quay.mycompany.internal/ee/mycompany-ee:latest
+  needs:
+    - lint
+```
+
+---
+
+## Enforcement
+
+Violations of this policy are caught by:
+
+1. **CI pipeline linting gate** — the Platform Team's shared CI template checks for `--mode stdout` compliance
+2. **Platform Team playbook review** — CI pipeline configurations are reviewed alongside playbooks during the [standard review process](playbook_review.md)
+
+Pipelines that use `--mode interactive` or `--mode tui` will be blocked by the linting gate and flagged for remediation.
+
+---
+
+## Summary
+
+> **The correct way to run `ansible-navigator` in any MyCompany CI pipeline is `ansible-navigator run <playbook> --mode stdout`. Interactive mode (`--mode interactive`) and TUI mode (`--mode tui`) are prohibited in CI contexts.**
+
+---
+
+## References
+
+- Playbook review process: [playbook_review.md](playbook_review.md)
+- Naming conventions: [naming_conventions.md](naming_conventions.md)
+- Troubleshooting failed CI jobs: [troubleshooting_escalation.md](troubleshooting_escalation.md)
+- Secrets in CI: [vault_secret lookup plugin](../lookup/vault_secret.md)
+- Starter CI templates: [https://gitlab.mycompany.internal/ansible/templates](https://gitlab.mycompany.internal/ansible/templates)

--- a/byok/ansible-collection-docs/policies/naming_conventions.md
+++ b/byok/ansible-collection-docs/policies/naming_conventions.md
@@ -1,0 +1,156 @@
+---
+title: "MyCompany Ansible Naming Conventions"
+url: "https://github.com/ansible/aap-rag-content/blob/main/byok/ansible-collection-docs/policies/naming_conventions.md"
+---
+# MyCompany Ansible Naming Conventions
+
+This document defines the mandatory naming standards for all Ansible automation assets at MyCompany Corp. All automation contributors must follow these conventions before submitting any playbook, role, or inventory for review.
+
+---
+
+## Roles
+
+### Naming Standard
+
+All custom Ansible roles **must** use the `mycompany_` prefix followed by a descriptive lowercase name with underscores separating words.
+
+**Pattern:** `mycompany_<descriptive_name>`
+
+**Examples:**
+
+| Correct | Incorrect |
+|---------|-----------|
+| `mycompany_webserver` | `webserver` |
+| `mycompany_database_backup` | `db-backup` |
+| `mycompany_monitoring_agent` | `monitoring` |
+| `mycompany_deploy_app` | `deploy` |
+
+The `mycompany_` prefix is required because:
+- It prevents naming collisions with community Galaxy roles
+- It signals that the role is owned and maintained by MyCompany Corp
+- It is enforced by the Platform Team's automated linting pipeline
+
+### Initializing a Role
+
+Use `ansible-galaxy` to scaffold a new role with the correct name:
+
+```bash
+ansible-galaxy role init mycompany_<descriptive_name>
+```
+
+Example:
+
+```bash
+ansible-galaxy role init mycompany_monitoring_agent
+```
+
+This creates the standard role directory structure under `roles/mycompany_monitoring_agent/`.
+
+### Role Directory Structure
+
+```
+roles/
+└── mycompany_monitoring_agent/
+    ├── defaults/
+    │   └── main.yml
+    ├── files/
+    ├── handlers/
+    │   └── main.yml
+    ├── meta/
+    │   └── main.yml
+    ├── tasks/
+    │   └── main.yml
+    ├── templates/
+    ├── tests/
+    │   ├── inventory
+    │   └── test.yml
+    └── vars/
+        └── main.yml
+```
+
+The `meta/main.yml` file **must** include the `galaxy_info.namespace` key set to `mycompany`.
+
+---
+
+## Inventory Groups
+
+### Naming Standard
+
+All Ansible inventory groups **must** follow the `mycompany_<env>_<tier>` pattern, where:
+
+- `<env>` identifies the deployment environment: `prod`, `staging`, `dev`, `qa`
+- `<tier>` identifies the infrastructure tier: `web`, `app`, `db`, `cache`, `worker`, `mgmt`
+
+**Pattern:** `mycompany_<env>_<tier>`
+
+**Examples:**
+
+| Group Name | Meaning |
+|-----------|---------|
+| `mycompany_prod_web` | Production web servers |
+| `mycompany_prod_db` | Production database servers |
+| `mycompany_staging_app` | Staging application servers |
+| `mycompany_dev_worker` | Development worker nodes |
+| `mycompany_qa_cache` | QA cache layer |
+| `mycompany_prod_mgmt` | Production management/bastion hosts |
+
+### Why This Pattern
+
+The `mycompany_<env>_<tier>` pattern provides:
+- **Consistency** — all groups are unambiguous at a glance
+- **Filterability** — you can target all production groups with `--limit 'mycompany_prod_*'`
+- **Collision avoidance** — the `mycompany_` prefix prevents conflicts with upstream community inventories
+
+### Group Variables
+
+Group variable files must follow the same pattern: `group_vars/mycompany_<env>_<tier>.yml`.
+
+```
+inventory/
+├── hosts.yml
+└── group_vars/
+    ├── mycompany_prod_web.yml
+    ├── mycompany_prod_db.yml
+    └── mycompany_staging_app.yml
+```
+
+---
+
+## Playbooks
+
+Playbook filenames should reflect their purpose and target environment:
+
+**Pattern:** `<action>_<component>[_<env>].yml`
+
+**Examples:**
+- `deploy_application_prod.yml`
+- `configure_database.yml`
+- `provision_server_staging.yml`
+
+---
+
+## Collections
+
+All internal MyCompany collections are namespaced under `mycompany.<collection_name>`.
+
+**Examples:**
+- `mycompany.infrastructure` — infrastructure provisioning and secrets
+- `mycompany.networking` — network configuration
+
+---
+
+## Enforcement
+
+Naming convention compliance is checked automatically by:
+- **Pre-commit hooks** in the GitLab CI pipeline
+- **Platform Team lint gate** during playbook review (see [Playbook Review Process](playbook_review.md))
+
+Submissions that do not follow these conventions will be rejected at the lint gate and must be corrected before the review SLA clock starts.
+
+---
+
+## References
+
+- Starter role templates: [https://gitlab.mycompany.internal/ansible/templates](https://gitlab.mycompany.internal/ansible/templates)
+- Playbook review process: [playbook_review.md](playbook_review.md)
+- Platform Team contact: `#platform-ops` on Slack

--- a/byok/ansible-collection-docs/policies/playbook_review.md
+++ b/byok/ansible-collection-docs/policies/playbook_review.md
@@ -1,0 +1,137 @@
+---
+title: "MyCompany Playbook Review and Approval Process"
+url: "https://github.com/ansible/aap-rag-content/blob/main/byok/ansible-collection-docs/policies/playbook_review.md"
+---
+# MyCompany Playbook Review and Approval Process
+
+All playbooks destined for the production environment must pass through the official MyCompany Corp review and approval process before deployment. This document describes the full process, SLAs, contacts, and exception handling.
+
+---
+
+## Overview
+
+The purpose of the playbook review process is to ensure that all automation deployed to production meets MyCompany's quality, security, and naming standards. The **Platform Team** is the approving authority for all production playbook deployments.
+
+---
+
+## Step-by-Step Review Process
+
+### 1. Prepare Your Playbook
+
+Before submitting for review, ensure your playbook:
+
+- Follows the [naming conventions](naming_conventions.md) (`mycompany_` prefix for roles, `mycompany_<env>_<tier>` for inventory groups)
+- Passes local lint checks: `ansible-lint` and `yamllint`
+- Has been tested in the `dev` or `staging` environment
+- Uses the `mycompany.infrastructure.vault_secret` lookup plugin for any secret retrieval (never hardcode secrets)
+- Uses starter templates from [https://gitlab.mycompany.internal/ansible/templates](https://gitlab.mycompany.internal/ansible/templates) as the base where applicable
+
+### 2. Open a Review Request
+
+Submit your playbook for review by opening a Merge Request (MR) in GitLab against the `main` branch of your project, then post a link to the MR in the **`#platform-ops`** Slack channel with the tag `[REVIEW REQUEST]`.
+
+**Example Slack message:**
+```
+[REVIEW REQUEST] MR: https://gitlab.mycompany.internal/ansible/my-project/-/merge_requests/42
+Purpose: Deploy monitoring agent to prod web tier
+Target: mycompany_prod_web
+```
+
+### 3. Platform Team Review
+
+The **Platform Team** will review the MR within **3 business days** (the SLA). The review covers:
+
+- Naming convention compliance
+- Security posture (no hardcoded secrets, correct vault usage)
+- Idempotency
+- Change scope (blast radius assessment)
+- Test coverage in staging
+
+### 4. Approval and Merge
+
+Once the Platform Team approves the MR, you may merge and schedule the production deployment. The Platform Team approval is required — **self-merging to production is not permitted**.
+
+---
+
+## Review SLA
+
+| Priority | SLA |
+|----------|-----|
+| Standard review | **3 business days** |
+| Emergency change | Same-day (see [Emergency Change Process](#emergency-change-process) below) |
+
+If your review has not received a response within the SLA, see [Escalating a Delayed Review](#escalating-a-delayed-review).
+
+---
+
+## Escalating a Delayed Review
+
+If your standard review is taking longer than **3 business days** and is blocking your work:
+
+1. **Post a follow-up** in `#platform-ops` on Slack, tagging `@platform-team` and referencing your original request
+2. **Contact your Team Lead** — ask them to escalate on your behalf to the Platform Team manager
+3. If still unresolved, your Team Lead can raise a priority escalation directly with the **On-Call SRE** for time-sensitive deployments
+
+---
+
+## Emergency Change Process
+
+Emergency changes are production deployments that cannot wait for the standard 3-day review window due to an active production incident or critical security patch.
+
+### Requirements
+
+1. **On-Call SRE Lead approval** — you must get verbal or Slack approval from the current On-Call SRE Lead before proceeding
+2. **Expedited Platform Team sign-off** — the On-Call SRE Lead will fast-track a Platform Team review
+3. **48-hour post-incident ticket** — within 48 hours after the emergency change is deployed, you must open a ticket in [Jira (INFRA project)](https://jira.mycompany.example/projects/INFRA) documenting:
+   - What was changed
+   - Why it was an emergency
+   - What the expected standard review would have caught
+   - Steps taken to prevent recurrence
+
+**Emergency changes that skip post-incident documentation will result in the requester's production deployment access being suspended.**
+
+### Emergency Change Checklist
+
+- [ ] Active production incident confirmed or critical CVE patched
+- [ ] On-Call SRE Lead approval obtained (record name and timestamp in the MR)
+- [ ] Expedited Platform Team review completed
+- [ ] Post-incident Jira ticket opened within 48 hours
+
+---
+
+## Contacts
+
+| Role | Contact |
+|------|---------|
+| Primary review channel | `#platform-ops` on Slack |
+| Platform Team DM | `@platform-team` on Slack |
+| On-Call SRE (current) | `#on-call-sre` on Slack or PagerDuty rotation |
+| Issue tracker | [https://jira.mycompany.example/projects/INFRA](https://jira.mycompany.example/projects/INFRA) |
+
+---
+
+## Starter Templates
+
+All new playbooks should be based on the approved starter templates available at:
+
+**[https://gitlab.mycompany.internal/ansible/templates](https://gitlab.mycompany.internal/ansible/templates)**
+
+The templates directory contains:
+
+| Template | Description |
+|----------|-------------|
+| `base_playbook.yml` | Minimal compliant playbook skeleton |
+| `role_deploy.yml` | Template for role-based deployment playbooks |
+| `maintenance_window.yml` | Template for maintenance window automation |
+| `emergency_patch.yml` | Template pre-approved for emergency change workflow |
+
+Using a starter template ensures naming conventions and required task patterns are pre-applied, reducing review friction.
+
+---
+
+## References
+
+- Naming conventions: [naming_conventions.md](naming_conventions.md)
+- Troubleshooting and escalation: [troubleshooting_escalation.md](troubleshooting_escalation.md)
+- CI automation policy: [ci_automation_policy.md](ci_automation_policy.md)
+- Platform Team GitLab: [https://gitlab.mycompany.internal/platform-eng](https://gitlab.mycompany.internal/platform-eng)

--- a/byok/ansible-collection-docs/policies/troubleshooting_escalation.md
+++ b/byok/ansible-collection-docs/policies/troubleshooting_escalation.md
@@ -1,0 +1,155 @@
+---
+title: "MyCompany Ansible Troubleshooting and Escalation Guide"
+url: "https://github.com/ansible/aap-rag-content/blob/main/byok/ansible-collection-docs/policies/troubleshooting_escalation.md"
+---
+# MyCompany Ansible Troubleshooting and Escalation Guide
+
+This guide describes the standard tools and escalation path for diagnosing and resolving failed Ansible jobs in the MyCompany Corp environment. Follow this guide whenever an automation job fails — especially in production.
+
+---
+
+## Debugging a Failed Ansible Job
+
+### Primary Tool: `mycompany-job-tracer`
+
+The standard tool for debugging failed Ansible jobs at MyCompany is **`mycompany-job-tracer`**.
+
+`mycompany-job-tracer` is a CLI utility maintained by the Platform Team that aggregates job logs, execution traces, and AAP event data into a single structured report. It is the first tool you should reach for when a job fails.
+
+#### Installation
+
+`mycompany-job-tracer` is pre-installed in all MyCompany execution environments. If it is missing, install it via:
+
+```bash
+pip install mycompany-job-tracer --extra-index-url https://pypi.mycompany.internal/simple
+```
+
+#### Basic Usage
+
+```bash
+# Trace the most recent failed job for a given job template
+mycompany-job-tracer --job-template "Deploy App - Prod" --status failed
+
+# Trace a specific job by ID
+mycompany-job-tracer --job-id 4821
+
+# Output a full structured report
+mycompany-job-tracer --job-id 4821 --format report --output /tmp/job-4821-report.txt
+
+# Filter by a specific task that failed
+mycompany-job-tracer --job-id 4821 --task "Deploy application"
+```
+
+#### What `mycompany-job-tracer` Provides
+
+| Output Section | Description |
+|---------------|-------------|
+| **Job summary** | Status, duration, host count, start/end timestamps |
+| **Failed tasks** | Task name, host, error message, return code |
+| **Variable dump** | Values of key variables at the point of failure |
+| **Event trace** | Full ordered event log from the AAP controller |
+| **Retry recommendation** | Whether the job is safe to retry as-is |
+
+#### Interpreting Output
+
+- **`TASK_FAILED: unreachable`** — connectivity or SSH issue; check the host and network
+- **`TASK_FAILED: permission_denied`** — credential issue; verify vault credentials via `mycompany.infrastructure.vault_secret`
+- **`TASK_FAILED: module_error`** — module-level failure; check the `mycompany.infrastructure` collection version compatibility
+
+---
+
+## Additional Debugging Steps
+
+If `mycompany-job-tracer` does not immediately reveal the cause, supplement with:
+
+1. **Re-run with increased verbosity** in AAP (set verbosity to 2 or 3 in the job template)
+2. **Check the AAP job event stream** for the `ERROR` event type
+3. **Review `mycompany.infrastructure` collection version** — run `ansible-galaxy collection list mycompany.infrastructure` to confirm the correct version is installed in the execution environment
+
+---
+
+## Escalation Path for Production Failures
+
+When a production job fails and cannot be resolved immediately using `mycompany-job-tracer`, follow this escalation path **in order**:
+
+```
+1. Team Lead
+      ↓  (if unresolved within 30 minutes)
+2. Platform Team  (#platform-ops on Slack)
+      ↓  (if unresolved within 1 hour or impact is critical)
+3. On-Call SRE
+```
+
+### Escalation Details
+
+#### Step 1: Team Lead
+
+Contact your immediate **Team Lead** first. They can:
+- Authorize a rollback if appropriate
+- Determine whether the failure meets the threshold for escalating to the Platform Team
+- Coordinate communication with stakeholders
+
+#### Step 2: Platform Team
+
+If the Team Lead cannot resolve the issue within **30 minutes**, escalate to the **Platform Team** via the `#platform-ops` Slack channel.
+
+Include in your escalation message:
+- Job ID and job template name
+- Environment affected (`mycompany_prod_*`, `mycompany_staging_*`, etc.)
+- Brief description of the failure
+- Output from `mycompany-job-tracer --job-id <ID> --format report`
+- Business impact (services affected, users impacted)
+
+#### Step 3: On-Call SRE
+
+If the Platform Team cannot resolve the issue within **1 hour**, or if the failure is causing immediate customer-facing impact, escalate to the **On-Call SRE** via:
+
+- Slack: `#on-call-sre`
+- PagerDuty: use the "Ansible Automation" escalation policy
+
+The On-Call SRE has authority to:
+- Authorize emergency rollbacks
+- Engage additional engineering resources
+- Declare an incident in the incident management system
+
+---
+
+## Emergency Change After Production Failure
+
+If the failure requires an emergency fix playbook deployment (bypassing the standard 3-day review SLA), follow the [Emergency Change Process](playbook_review.md#emergency-change-process):
+
+1. Obtain **On-Call SRE Lead approval** before deploying
+2. Complete an expedited Platform Team review
+3. Open a **48-hour post-incident Jira ticket** in the [INFRA project](https://jira.mycompany.example/projects/INFRA)
+
+---
+
+## Common Failure Patterns and Resolutions
+
+| Failure Pattern | Likely Cause | Resolution |
+|----------------|--------------|------------|
+| `vault_secret` lookup fails | Vault token expired or wrong path | Re-authenticate; verify `vault_url` in `ansible.cfg` `[mycompany_infrastructure]` section |
+| `create_server` times out | Cloud API rate limit or quota | Check cloud console; retry after 15 minutes |
+| `dynamic_cloud` inventory empty | Cloud credentials expired | Rotate credentials; re-run inventory sync |
+| Job succeeds in staging but fails in prod | Environment variable mismatch | Compare `group_vars/mycompany_staging_*` vs `mycompany_prod_*` |
+| Escalation to On-Call SRE not acknowledged | PagerDuty misconfiguration | Contact SRE manager directly via `#sre-leadership` |
+
+---
+
+## Contacts
+
+| Role | Contact |
+|------|---------|
+| Platform Team | `#platform-ops` on Slack |
+| On-Call SRE | `#on-call-sre` on Slack, PagerDuty "Ansible Automation" policy |
+| Incident management | https://jira.mycompany.example/projects/INFRA |
+| mycompany-job-tracer issues | https://jira.mycompany.example/projects/TOOLS |
+
+---
+
+## References
+
+- Playbook review and emergency change process: [playbook_review.md](playbook_review.md)
+- CI automation policy: [ci_automation_policy.md](ci_automation_policy.md)
+- `mycompany.infrastructure` collection: [README.md](../README.md)
+- `mycompany.infrastructure.vault_secret` plugin: [vault_secret.md](../lookup/vault_secret.md)


### PR DESCRIPTION
# Ticket
https://redhat.atlassian.net/browse/AAP-71672


# Summary
                                                                                                                                                                                                                                  
Adds four fictional org policy documents to the BYOK example content under `byok/ansible-collection-docs/policies/`. These documents extend the existing `mycompany.infrastructure` collection sample to include an organizational    
knowledge layer, enabling more realistic testathon scenarios for the BYOK RAG feature.                                                                                                                                            
                                                                                                                                                                                                                                  
The new files cover:                                      
- `ci_automation_policy.md` — Mandates ansible-navigator run --mode stdout in CI pipelines; explains why interactive modes are prohibited in headless runners
- `naming_conventions.md` — Defines mycompany_ prefix rules for roles, mycompany_<env>_<tier> pattern for inventory groups, and collection namespacing                                                                              
- `playbook_review.md` — Documents the Platform Team review process, 3-day SLA, escalation path, and emergency change procedure                       
- `troubleshooting_escalation.md` — Describes mycompany-job-tracer usage and the production escalation chain (Team Lead → Platform Team → On-Call SRE)                                                                              
                                                                                                                                                                                                                                  
# Why                                                                                                                                                                                                                               
                                                                                                                                                                                                                                  
The original BYOK example content covered collection modules, lookups, and filters but lacked org-policy-style documents. Policy content exercises a distinct RAG retrieval pattern — users ask procedural questions ("How do I   
escalate?", "What naming convention should I use?") rather than API-lookup questions. Adding this layer makes the testathon validation more representative of real BYOK deployments.
