### PR TITLE
AAP-63658: Exclude embedding model from BYOK image by default

### DIFF
--- a/.github/workflows/generate-byok-vector-db.yml
+++ b/.github/workflows/generate-byok-vector-db.yml
@@ -26,7 +26,7 @@ on:
       include_model:
         description: 'Include the embedding model in the output image (true/false)'
         required: true
-        default: 'true'
+        default: 'false'
       quay_repository:
         description: 'Quay.io repository to push the output image to'
         required: true
@@ -52,7 +52,7 @@ jobs:
         run: |
           NO_MODEL_FLAG=""
           if [ "${{ inputs.include_model }}" = "false" ]; then
-            NO_MODEL_FLAG="--no-include-model"
+            NO_MODEL_FLAG="--exclude-model"
           fi
 
           docker run --rm \

--- a/byok/README.md
+++ b/byok/README.md
@@ -113,7 +113,7 @@ podman run --rm \
 | | `--output-image` | Path for the output `.tar` image archive (required) |
 | | `--image-name` | Repository name embedded in the image archive (default: `rag-content-output`) |
 | | `--image-tag` | Tag embedded in the image archive (default: `latest`) |
-| | `--no-include-model` | Exclude the embedding model from the output image (included by default) |
+| | `--exclude-model` | Exclude the embedding model from the output image (included by default) |
 
 > **Note:** `--userns=keep-id` is required so the container process runs as your host UID
 > and can write to the output directory.


### PR DESCRIPTION
#  Summary

  - Fixes the --no-include-model flag used in the generate-byok-vector-db workflow — the rag-content tool only accepts --exclude-model; the previous flag was silently ignored, so the model was always bundled regardless of the
  include_model input.
  - Flips the include_model workflow input default from true to false, so the generated BYOK image excludes the embedding model unless the caller explicitly opts in. This produces smaller images and aligns with the expected BYOK
   deployment model where the embedding model is provided separately at runtime.
  - Updates byok/README.md to document the correct --exclude-model flag
