### PR TITLE
Fix PYTHONPATH escape in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       #   run: make check-types
 
       - name: Run unit tests with coverage
-        run: PYTHONPATH=src:$$PYTHONPATH uv run pytest tests/ -v -c pyproject.toml --cov=src --cov=scripts --cov-report=xml --cov-report=term
+        run: PYTHONPATH=src:$PYTHONPATH uv run pytest tests/ -v -c pyproject.toml --cov=src --cov=scripts --cov-report=xml --cov-report=term
 
       # Fix paths in coverage file for SonarCloud
       # See https://sonarsource.atlassian.net/browse/SONARPY-1203


### PR DESCRIPTION
## Summary

One-character fix: `PYTHONPATH=src:$$PYTHONPATH` → `PYTHONPATH=src:$PYTHONPATH` in `test.yml`.

The `$$` was carried over from a Makefile pattern (where `$$` escapes to `$` for the shell). In a GitHub Actions `run:` step the shell receives `$$` literally, which expands to the shell's PID — producing `PYTHONPATH=src:<pid>` instead of preserving any existing `PYTHONPATH`.

In practice CI starts with `PYTHONPATH` empty so the bogus `<pid>` path is silently ignored and tests pass. Fixing the literal intent regardless.

## Context

Same fix as [ansible-automation-platform/aap-rag-content#27](https://github.com/ansible-automation-platform/aap-rag-content/pull/27) (downstream stable-2.6 backport). Originally reported by `@jameswnl` on the parent backport PR.

The downstream `ansible-automation-platform/aap-rag-content` `main` branch will pick this up automatically via the repo-sync workflow once this lands.

## Test plan

- [ ] CI on this branch should run and pass with the corrected escape — same behavior as before since CI's `PYTHONPATH` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)