### PR TITLE
Add Codecov integration for code coverage tracking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,21 @@ jobs:
           if-no-files-found: warn
 
       #####################
+      # Upload coverage to Codecov
+      #####################
+      - name: Upload Python coverage to Codecov
+        # Skip for fork PRs where secrets are not available
+        if: always() && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request')
+        uses: codecov/codecov-action@0f8570b1a125f4937846a11fcfa3bcd548bd8c97 # v4.6.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          url: ${{ vars.CODECOV_URL }}
+          files: ./coverage.xml
+          flags: python
+          disable_search: true
+          fail_ci_if_error: false
+
+      #####################
       # SonarCloud analysis
       #####################
       - name: Extract repo owner and name

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,33 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+
+  # Align with SonarCloud exclusions from sonar-project.properties
+  ignore:
+    # Python test files
+    - "tests/**/*"
+    # Python cache and artifacts
+    - "**/__pycache__/**"
+    - "**/*.pyc"
+    - "**/.pytest_cache/**"
+    # Python migrations
+    - "**/migrations/**"
+
+flags:
+  python:
+    carryforward: true
+    paths:
+      - src/
+      - scripts/
+      - embeddings_model/
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false
+  require_base: true
+  require_head: true


### PR DESCRIPTION
## Summary
Adds Codecov integration to track code coverage metrics alongside SonarCloud, providing unified coverage reporting and PR annotations.

## Changes
- **codecov.yml**: Configuration file with exclusions aligned to SonarCloud
- **.github/workflows/test.yml**: Added Codecov upload step after coverage generation
- **CODECOV_CONFIG.md**: Comprehensive documentation of the Codecov setup

## Configuration Details

### Coverage Source
- **Unified metrics**: Both SonarCloud and Codecov consume the same `coverage.xml` file
- **Coverage paths**: `src/`, `scripts/`, `embeddings_model/`
- **Aligned exclusions**: Tests, migrations, cache files (same as SonarCloud)

### Workflow Integration
- **Runs on**: main branch pushes and PRs targeting main
- **Organization filter**: Only runs for `ansible` organization
- **Token setup**: Uses `CODECOV_TOKEN` secret and `CODECOV_URL` variable (same pattern as ansible-ai-connect-service)
- **Fork PR handling**: Skips both SonarCloud and Codecov for fork PRs (secrets unavailable)
- **Error handling**: Non-blocking (`fail_ci_if_error: false`)

### Features
- **Python flag**: Single flag with carryforward support for partial test runs
- **PR comments**: Coverage diff and file-by-file breakdown on PRs
- **Coverage trends**: Historical tracking in Codecov dashboard
- **Quality metrics**: Complementary to SonarCloud's quality analysis

## Prerequisites (Required before merge)

The following must be configured in repository settings for the workflow to succeed:

### Secrets (Settings → Secrets and variables → Actions → Secrets)
- [ ] **CODECOV_TOKEN**: Repository upload token from Codecov dashboard

### Variables (Settings → Secrets and variables → Actions → Variables)
- [ ] **CODECOV_URL**: Codecov API endpoint (e.g., `https://codecov.io` or enterprise URL)

## Testing Plan
1. Verify workflow runs successfully after secret/variable configuration
2. Check Codecov dashboard shows coverage metrics
3. Confirm PR comment appears with coverage diff
4. Validate SonarCloud and Codecov show matching coverage percentages

## Documentation
See [CODECOV_CONFIG.md](./CODECOV_CONFIG.md) for complete setup guide, troubleshooting, and maintenance instructions.

## References
- Based on configuration from [ansible-ai-connect-service](https://github.com/ansible/ansible-ai-connect-service)
- Aligned with existing SonarCloud configuration
- Uses Codecov GitHub Action v4.6.0 (SHA-pinned for security)