### PR TITLE
Remove redundant exception types already covered by OSError

### DIFF
--- a/scripts/solution-guides-parser.py
+++ b/scripts/solution-guides-parser.py
@@ -109,7 +109,7 @@ class SolutionGuidesParser:
                     open(dest, "wb") as out,
                 ):
                     shutil.copyfileobj(response, out)
-            except (urllib.error.URLError, TimeoutError, OSError) as e:
+            except OSError as e:
                 print(
                     f"ERROR: failed to download {source_file}: {e}",
                     file=sys.stderr,


### PR DESCRIPTION
urllib.error.URLError and TimeoutError are both subclasses of OSError, making them redundant in the except clause.