### PR TITLE
AAP-78033: Bump PyJWT to >=2.13.0 (CVE-2026-48526)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "llama-stack==0.4.3",
     "llama-stack-api==0.4.4",  # Must match llama-stack version
     "pillow==12.2.0", # Transient dep pinned to handle CVE-2026-40192
+    "pyjwt>=2.13.0",  # Transient dep pinned for CVE-2026-48526
     "python-dotenv>=1.2.2", # CVE-2026-28684
     "pyasn1==0.6.3",
     "python-multipart==0.0.22", # Transient dep pinned to handle CVE

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ dependencies = [
     { name = "llama-stack-client" },
     { name = "pillow" },
     { name = "pyasn1" },
+    { name = "pyjwt" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "requests" },
@@ -57,6 +58,7 @@ requires-dist = [
     { name = "llama-stack-client", specifier = "==0.4.3" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "pyasn1", specifier = "==0.6.3" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = "==0.0.22" },
     { name = "requests", specifier = "==2.32.5" },
@@ -1242,11 +1244,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Security fix: Pin `pyjwt>=2.13.0` to address CVE-2026-48526 (authentication bypass due to forged JSON Web Tokens).

PyJWT is a transitive dependency brought in by `llama-stack`. Previously resolved to 2.12.1, now pinned to >=2.13.0 in `pyproject.toml` and lockfile regenerated.

- [x] This is a security fix
- **Jira**: [AAP-78033](https://redhat.atlassian.net/browse/AAP-78033)
- **CVE**: [CVE-2026-48526](https://access.redhat.com/security/cve/CVE-2026-48526)
- **Fix version**: PyJWT >= 2.13.0

### Backport policy

Downstream stable-2.6 needs the same pin (separate PR). Downstream stable-2.7 already has `pyjwt>=2.13.0`.

### Testing

- `uv lock` resolves successfully
- `uv lock --check` passes
- PyJWT 2.13.0 confirmed in lockfile

Made with [Cursor](https://cursor.com)