### PR TITLE
AAP-80693: Bump python-multipart to 0.0.27 (CVE-2026-42561)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
     "pyjwt>=2.13.0",  # Transient dep pinned for CVE-2026-48526
     "python-dotenv>=1.2.2", # CVE-2026-28684
     "pyasn1==0.6.3",
-    "python-multipart==0.0.22", # Transient dep pinned to handle CVE
+    "python-multipart==0.0.27", # CVE-2026-42561
     "requests==2.32.5",
     "sentence-transformers==5.3.0",
     "sqlalchemy[asyncio]==2.0.46",

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ requires-dist = [
     { name = "pyasn1", specifier = "==0.6.3" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
-    { name = "python-multipart", specifier = "==0.0.22" },
+    { name = "python-multipart", specifier = "==0.0.27" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "sentence-transformers", specifier = "==5.3.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = "==2.0.46" },
@@ -1321,11 +1321,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `python-multipart` from 0.0.22 to 0.0.27 to address CVE-2026-42561.

**CVE-2026-42561:** python-multipart DoS via excessive multipart part headers. Prior to 0.0.27, MultipartParser had no limit on the number of part headers or the size of an individual header, allowing CPU exhaustion via crafted requests.

- [x] Security fix (no functional changes)
- [x] Backport to stable-2.6 and stable-2.7 required

**Jira:** [AAP-80693](https://issues.redhat.com/browse/AAP-80693)

## Risk Assessment

- **Risk:** Medium (DoS, network-facing, production dep)
- **Exposure:** multipart form parsing in FastAPI/Starlette

## Test Plan

- Existing test suite should pass (no API changes in python-multipart 0.0.22→0.0.27)
- Verify multipart file upload endpoints still function

Made with [Cursor](https://cursor.com)