### PR TITLE
AAP-83418: Bump pyasn1 to 0.6.4 (CVE-2026-59886)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     "pillow==12.3.0", # Transient dep pinned to handle CVE (CVE-2026-40192, CVE-2026-59197, CVE-2026-54058, CVE-2026-54060, CVE-2026-55380, CVE-2026-55379)
     "pyjwt>=2.13.0",  # Transient dep pinned for CVE-2026-48526
     "python-dotenv>=1.2.2", # CVE-2026-28684
-    "pyasn1==0.6.3",
+    "pyasn1==0.6.4",  # CVE-2026-59886
     "python-multipart==0.0.27", # CVE-2026-42561
     "requests==2.32.5",
     "sentence-transformers==5.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1766,9 +1766,9 @@ pyaml==26.2.1 \
     --hash=sha256:489dd82997235d4cfcf76a6287fce2f075487d77a6567c271e8d790583690c68 \
     --hash=sha256:6261c2f0a2f33245286c794ad6ec234be33a73d2b05427079fd343e2812a87cf
     # via llama-stack-client
-pyasn1==0.6.3 \
-    --hash=sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf \
-    --hash=sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde
+pyasn1==0.6.4 \
+    --hash=sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81 \
+    --hash=sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b
     # via aap-rag-content (pyproject.toml)
 pycparser==3.0 \
     --hash=sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29 \

--- a/uv.lock
+++ b/uv.lock
@@ -57,7 +57,7 @@ requires-dist = [
     { name = "llama-stack-api", specifier = "==0.4.4" },
     { name = "llama-stack-client", specifier = "==0.4.3" },
     { name = "pillow", specifier = "==12.3.0" },
-    { name = "pyasn1", specifier = "==0.6.3" },
+    { name = "pyasn1", specifier = "==0.6.4" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = "==0.0.27" },
@@ -1173,11 +1173,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-83418

## Description

Bumps `pyasn1` to the latest release **0.6.4** to fix **CVE-2026-59886** (Red Hat: Important, CVSS 7.5).

`pyasn1 < 0.6.4` decodes a BER/CER/DER-encoded `REAL` value's mantissa/base/exponent to a Python float using exact big-integer exponentiation. A short encoded value can carry a very large exponent, so `prettyPrint()`, `str()`, comparison, arithmetic, `int()`, or `float()` on the decoded value consumes excessive CPU/memory — a denial of service.

`pyasn1` is a direct, pinned dependency of this project. Only the dependency version changed — no source changes.

| Package | Old | New | CVE |
|---------|-----|-----|-----|
| pyasn1 | 0.6.3 | 0.6.4 | CVE-2026-59886 |

## Testing
### Steps to test
1. Pull down the PR
2. `uv lock --check` — passes
3. `pip-audit -r requirements.txt` — no CVE-2026-59886

## Type of Change
- [x] Security fix

## Backport Policy

This change should be:
- [x] **Backported** to specific releases — this is the mainline (upstream) fix; it mirrors to downstream `main` via repo-sync. Equivalent downstream release-branch PRs: `stable-2.7` (#57) and `stable-2.6` (#58).

### Scenarios tested
- `uv lock --check` passes; `uv.lock`, `requirements.txt`, and `pyproject.toml` all pin `pyasn1==0.6.4`
- Diff is limited to the `pyasn1` entry — no other package moved

## Production deployment
- [x] This code change is ready for production on its own

🤖 Generated with [Claude Code](https://claude.com/claude-code)
