### PR TITLE
fix: stop renovate.json from orphaning requirements.txt

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "pip-compile": {
-    "enabled": true,
-    "managerFilePatterns": [
-      "/^requirements\\.txt$/"
-    ]
-  },
-  "pip_requirements": {
-    "enabled": false
-  },
-  "pip_setup": {
-    "enabled": false
-  },
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": false


### PR DESCRIPTION
## What

Drop the pip manager overrides added in #389, keeping only
`lockFileMaintenance`. The `=`-form compile command from #389 — the actual
remedy — is retained.

## Why

#389 disabled `pip_requirements` and enabled `pip-compile` in its place. The
disabling worked; the replacement did not engage. **Nothing manages
`requirements.txt` now.**

Evidence, with a control:

```
pre-#389   #381, #382         touched requirements.txt
post-#389  #386, #387, #390   pyproject.toml + uv.lock only
```

#390 bumps `llama-stack-client` 0.4.3 → 0.7.5 in `pyproject.toml` and
`uv.lock` while `requirements.txt` stays at 0.4.3. Merging it reintroduces
exactly the drift #383 removed — in the file `Containerfile-aap` installs
from.

Likely cause is `managerFilePatterns`, which this MintMaker's Renovate
version may not honour (older Renovate uses `fileMatch`). With no usable
pattern, `pip-compile` matches nothing while `pip_requirements` stays off.

## Why remove rather than fix the key

`ansible-lightspeed-chatbot-container` has **no `renovate.json` at all**, and
its MintMaker PRs recompile `requirements.txt` with hashes correctly updated.
The default state is known-good; guessing at the right key is not.

#389's own description said the header change alone might be sufficient. The
config was added on top without being verified — that was the error.

## Verification needed

This is not proven until the next MintMaker PR touches `requirements.txt`
again with hashes updated alongside versions. Worth watching before merging
#386, #387 or #390.

## Scope

Upstream `main`. One file, 12 deletions.
