### PR TITLE
fix: add upper version caps for cryptography and starlette

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     # https://github.com/llamastack/llama-stack/issues/4587
     "aiosqlite==0.22.1",
     "chardet==5.2.0",
-    "cryptography==50.0.0", # Transient dep pinned to handle CVE
+    "cryptography>=50.0.0,<51", # Transient dep pinned to handle CVE
     "faiss-cpu==1.12",
     "filelock==3.32.2",
     "llama-stack-client==0.4.3",
@@ -77,7 +77,7 @@ dependencies = [
     "requests==2.34.2",
     "sentence-transformers==5.3.0",
     "sqlalchemy[asyncio]==2.0.51",
-    "starlette>=1.3.1",  # Bumped for CVE-2026-54283
+    "starlette>=1.3.1,<2",  # Bumped for CVE-2026-54283
     "torch",
     "urllib3==2.7.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -52,7 +52,7 @@ requires-dist = [
     { name = "aiohttp", specifier = "==3.14.3" },
     { name = "aiosqlite", specifier = "==0.22.1" },
     { name = "chardet", specifier = "==5.2.0" },
-    { name = "cryptography", specifier = "==50.0.0" },
+    { name = "cryptography", specifier = ">=50.0.0,<51" },
     { name = "faiss-cpu", specifier = "==1.12" },
     { name = "filelock", specifier = "==3.32.2" },
     { name = "llama-stack", specifier = "==0.4.3" },
@@ -66,7 +66,7 @@ requires-dist = [
     { name = "requests", specifier = "==2.34.2" },
     { name = "sentence-transformers", specifier = "==5.3.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = "==2.0.51" },
-    { name = "starlette", specifier = ">=1.3.1" },
+    { name = "starlette", specifier = ">=1.3.1,<2" },
     { name = "torch", marker = "sys_platform != 'darwin'", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torch", marker = "sys_platform == 'darwin'" },
     { name = "urllib3", specifier = "==2.7.0" },
@@ -1748,13 +1748,13 @@ resolution-markers = [
     "sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "sympy", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
@@ -1770,13 +1770,13 @@ resolution-markers = [
     "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", marker = "sys_platform != 'darwin'" },
+    { name = "setuptools", marker = "sys_platform != 'darwin'" },
+    { name = "sympy", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:ffadde149901c8afa138daa38d898264003cfcf1a3336ca5cd964b5af227d867", upload-time = "2026-07-08T19:28:41Z" },


### PR DESCRIPTION
## Summary
- Caps `cryptography` to `>=50.0.0,<51` (was `==50.0.0`) to allow patch updates within v50 while preventing a v51+ major bump
- Caps `starlette` to `>=1.3.1,<2` (was `>=1.3.1`) to prevent a v2 major version upgrade

These caps guard against unintended breaking changes from major version bumps in transitive or pinned CVE dependencies.

## Test plan
- [ ] CI passes (lockfile consistency, tests)
- [ ] Verify resolved versions remain `cryptography==50.0.0` and `starlette==1.3.1` (caps only constrain future upgrades)

Made with [Cursor](https://cursor.com)