### PR TITLE
refactor: reduce cognitive complexity in 3 of 6 flagged functions

### DIFF
--- a/scripts/mimir-parser.py
+++ b/scripts/mimir-parser.py
@@ -240,10 +240,103 @@ class MimirParser:  # pylint: disable=too-many-instance-attributes
             self.process_md()
 
 
-def main():  # pragma: no cover  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+def _decrypt_and_extract_archive(in_file, out_file):  # pragma: no cover
+    """Decrypt the Mimir archive and extract the configured source directories."""
+    secret = os.getenv("MIMIR_ENC_SECRET")
+    if not secret:
+        print("Envvar MIMIR_ENC_SECRET is not defined.")
+        sys.exit(1)
+    openssl_cmd = (
+        f"openssl enc -aes-256-cbc -d -pbkdf2"
+        f" -pass pass:{secret}"
+        f" -in {in_file} -out {out_file}"
+    )
+    subprocess.run(openssl_cmd.split(" "), capture_output=True, text=True, check=True)
+    dirs = " ".join(SOURCE_DIRS)
+    output = subprocess.run(
+        f"tar xvzf {out_file} {dirs}".split(" "), capture_output=True, text=True, check=True
+    )
+    print(output)
+
+
+def _generate_toc_files():  # pragma: no cover
+    """Generate TOC json files from AEM HTML pages for each source directory."""
+    print("Generating TOC files from AEM HTML files...")
+    toc_script = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "aem-toc-generator.py"
+    )
+    for source_dir in SOURCE_DIRS:
+        if not os.path.isdir(source_dir):
+            continue
+        for doc_name in sorted(os.listdir(source_dir)):
+            aem_dir = os.path.join(source_dir, doc_name, "aem-page")
+            if not os.path.isdir(aem_dir):
+                continue
+            html_files = [f for f in os.listdir(aem_dir) if f.endswith(".html")]
+            if not html_files:
+                continue
+            input_path = os.path.join(aem_dir, html_files[0])
+            output_path = os.path.join(source_dir, doc_name, "toc", "toc.json")
+            subprocess.run(
+                [sys.executable, toc_script, "-i", input_path, "-o", output_path],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+    print("TOC generation complete.")
+
+
+def _extract_kb_articles(out_file):  # pragma: no cover
+    """Extract knowledge base articles from the archive."""
+    print("Extracting knowledge base articles...")
+    output = subprocess.run(
+        f"tar xzf {out_file} {KNOWLEDGE_BASE_ARTICLES_DIR}".split(" "),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    print(output.stdout)
+    print(output.stderr)
+    print("done!")
+
+
+def _cleanup_html_files():  # pragma: no cover
+    """Delete extracted HTML files, now that TOC/plaintext generation is done."""
+    print("Delete html files")
+    output = subprocess.run(
+        "find red_hat_content -name *.html -type f -delete".split(" "),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    print(output)
+
+
+def _process_mimir_archive(in_file, out_file, args):  # pragma: no cover
+    """Decrypt, extract and post-process the Mimir archive, cleaning up on exit."""
+    try:
+        _decrypt_and_extract_archive(in_file, out_file)
+        _generate_toc_files()
+        if args.add_kb_articles:
+            _extract_kb_articles(out_file)
+        if args.keep_html:
+            print("Keeping html files")
+        else:
+            _cleanup_html_files()
+    except subprocess.CalledProcessError:
+        traceback.print_stack()
+        sys.exit(2)
+    finally:
+        if os.path.exists(in_file):
+            os.unlink(in_file)
+        if os.path.exists(out_file):
+            os.unlink(out_file)
+
+
+def main():  # pragma: no cover
     """Extract and parse Mimir archives into plaintext for RAG."""
     start = time.time()
-    try:  # pylint: disable=too-many-nested-blocks
+    try:
         arg_parser = argparse.ArgumentParser()
         arg_parser.add_argument("-o", "--out-dir", default="aap-product-docs-plaintext")
         arg_parser.add_argument("-m", "--max-level", default=3)
@@ -264,91 +357,7 @@ def main():  # pragma: no cover  # pylint: disable=too-many-locals,too-many-bran
         out_file = "mimir/mimir-extract-latest.tgz"
         in_file = out_file + ".enc"
         if os.path.exists(in_file):
-            try:
-                secret = os.getenv("MIMIR_ENC_SECRET")
-                if not secret:
-                    print("Envvar MIMIR_ENC_SECRET is not defined.")
-                    sys.exit(1)
-                openssl_cmd = (
-                    f"openssl enc -aes-256-cbc -d -pbkdf2"
-                    f" -pass pass:{secret}"
-                    f" -in {in_file} -out {out_file}"
-                )
-                subprocess.run(
-                    openssl_cmd.split(" "),
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-                dirs = " ".join(SOURCE_DIRS)
-                output = subprocess.run(
-                    f"tar xvzf {out_file} {dirs}".split(" "),
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-                print(output)
-                print("Generating TOC files from AEM HTML files...")
-                toc_script = os.path.join(
-                    os.path.dirname(os.path.abspath(__file__)),
-                    "aem-toc-generator.py",
-                )
-                for source_dir in SOURCE_DIRS:
-                    if not os.path.isdir(source_dir):
-                        continue
-                    for doc_name in sorted(os.listdir(source_dir)):
-                        aem_dir = os.path.join(source_dir, doc_name, "aem-page")
-                        if not os.path.isdir(aem_dir):
-                            continue
-                        html_files = [f for f in os.listdir(aem_dir) if f.endswith(".html")]
-                        if not html_files:
-                            continue
-                        input_path = os.path.join(aem_dir, html_files[0])
-                        output_path = os.path.join(source_dir, doc_name, "toc", "toc.json")
-                        subprocess.run(
-                            [
-                                sys.executable,
-                                toc_script,
-                                "-i",
-                                input_path,
-                                "-o",
-                                output_path,
-                            ],
-                            capture_output=True,
-                            text=True,
-                            check=True,
-                        )
-                print("TOC generation complete.")
-                if args.add_kb_articles:
-                    print("Extracting knowledge base articles...")
-                    output = subprocess.run(
-                        f"tar xzf {out_file} {KNOWLEDGE_BASE_ARTICLES_DIR}".split(" "),
-                        capture_output=True,
-                        text=True,
-                        check=True,
-                    )
-                    print(output.stdout)
-                    print(output.stderr)
-                    print("done!")
-                if args.keep_html:
-                    print("Keeping html files")
-                else:
-                    print("Delete html files")
-                    output = subprocess.run(
-                        "find red_hat_content -name *.html -type f -delete".split(" "),
-                        capture_output=True,
-                        text=True,
-                        check=True,
-                    )
-                    print(output)
-            except subprocess.CalledProcessError:
-                traceback.print_stack()
-                sys.exit(2)
-            finally:
-                if os.path.exists(in_file):
-                    os.unlink(in_file)
-                if os.path.exists(out_file):
-                    os.unlink(out_file)
+            _process_mimir_archive(in_file, out_file, args)
         else:
             print(f"{in_file} is not found. Skip the file extraction step.")
 

--- a/scripts/mimir-parser.py
+++ b/scripts/mimir-parser.py
@@ -246,15 +246,21 @@ def _decrypt_and_extract_archive(in_file, out_file):  # pragma: no cover
     if not secret:
         print("Envvar MIMIR_ENC_SECRET is not defined.")
         sys.exit(1)
-    openssl_cmd = (
-        f"openssl enc -aes-256-cbc -d -pbkdf2"
-        f" -pass pass:{secret}"
-        f" -in {in_file} -out {out_file}"
+    subprocess.run(
+        [
+            "openssl", "enc", "-aes-256-cbc", "-d", "-pbkdf2",
+            "-pass", f"pass:{secret}",
+            "-in", in_file, "-out", out_file,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
     )
-    subprocess.run(openssl_cmd.split(" "), capture_output=True, text=True, check=True)
-    dirs = " ".join(SOURCE_DIRS)
     output = subprocess.run(
-        f"tar xvzf {out_file} {dirs}".split(" "), capture_output=True, text=True, check=True
+        ["tar", "xvzf", out_file, *SOURCE_DIRS],
+        capture_output=True,
+        text=True,
+        check=True,
     )
     print(output)
 
@@ -290,7 +296,7 @@ def _extract_kb_articles(out_file):  # pragma: no cover
     """Extract knowledge base articles from the archive."""
     print("Extracting knowledge base articles...")
     output = subprocess.run(
-        f"tar xzf {out_file} {KNOWLEDGE_BASE_ARTICLES_DIR}".split(" "),
+        ["tar", "xzf", out_file, KNOWLEDGE_BASE_ARTICLES_DIR],
         capture_output=True,
         text=True,
         check=True,
@@ -304,7 +310,7 @@ def _cleanup_html_files():  # pragma: no cover
     """Delete extracted HTML files, now that TOC/plaintext generation is done."""
     print("Delete html files")
     output = subprocess.run(
-        "find red_hat_content -name *.html -type f -delete".split(" "),
+        ["find", "red_hat_content", "-name", "*.html", "-type", "f", "-delete"],
         capture_output=True,
         text=True,
         check=True,

--- a/src/aap_rag_content/document_processor.py
+++ b/src/aap_rag_content/document_processor.py
@@ -498,9 +498,98 @@ registered_resources:
         )
         return str(vector_store.id)
 
-    async def _upload_and_process_files(  # noqa: C901  # pylint: disable=R0912,R0914
-        self, client: Any, index: str
-    ) -> str:
+    async def _wait_for_file_processing(
+        self, client: Any, vector_store_id: str, file_id: str, max_wait: int = 5 * 60
+    ) -> Any:
+        """Poll a vector store file until it reaches a terminal status.
+
+        Returns:
+            The last-retrieved file object (its .status may still be non-terminal
+            if max_wait was exceeded).
+        """
+        vs_file = await client.vector_stores.files.retrieve(
+            vector_store_id=vector_store_id,
+            file_id=file_id,
+        )
+        start_time = time.time()
+        while (time.time() - start_time) < max_wait:
+            if vs_file.status in ("completed", "failed", "cancelled"):
+                break
+            await asyncio.sleep(0.5)
+            vs_file = await client.vector_stores.files.retrieve(
+                vector_store_id=vector_store_id,
+                file_id=file_id,
+            )
+        return vs_file
+
+    async def _upload_single_file_with_retry(
+        self,
+        client: Any,
+        vector_store: Any,
+        rag_doc: Any,
+        chunking_strategy: dict[str, Any],
+        max_retries: int = 3,
+    ) -> tuple[bool, Optional[str]]:
+        """Upload one file (auto-chunking mode), retrying on failure.
+
+        Returns:
+            (success, error) — error is None when success is True.
+        """
+        doc_uuid = rag_doc.document_id  # type: ignore[union-attr]
+        error: Optional[str] = None
+
+        for attempt in range(max_retries):
+            try:
+                file_obj = BytesIO(rag_doc.content.encode("utf-8"))  # type: ignore[union-attr]
+                file_obj.name = f"{doc_uuid}.txt"
+
+                uploaded_file = await client.files.create(
+                    file=file_obj,
+                    purpose="assistants",
+                )
+
+                attributes = {
+                    **rag_doc.metadata,  # type: ignore[union-attr]
+                    "document_id": doc_uuid,
+                }
+                await client.vector_stores.files.create(
+                    vector_store_id=vector_store.id,
+                    file_id=uploaded_file.id,
+                    attributes=attributes,
+                    chunking_strategy=chunking_strategy,
+                )
+
+                vs_file = await self._wait_for_file_processing(
+                    client, vector_store.id, uploaded_file.id
+                )
+
+                if vs_file.status == "completed":
+                    return True, None
+
+                error = getattr(vs_file, "last_error", "unknown error")
+                LOG.warning(
+                    "File %s attempt %d/%d failed: %s",
+                    doc_uuid,
+                    attempt + 1,
+                    max_retries,
+                    error,
+                )
+
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                error = str(e)
+                LOG.warning(
+                    "File %s attempt %d/%d error: %s",
+                    doc_uuid,
+                    attempt + 1,
+                    max_retries,
+                    e,
+                )
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(1)
+
+        return False, error
+
+    async def _upload_and_process_files(self, client: Any, index: str) -> str:
         """Auto chunking: Upload and process files one at a time.
 
         Called when --auto-chunking flag enabled.
@@ -534,77 +623,17 @@ registered_resources:
         LOG.info("Processing %d files...", total_docs)
 
         for idx, rag_doc in enumerate(self.documents):
-            doc_uuid = rag_doc.document_id  # type: ignore[union-attr]
-            max_retries = 3
-
-            for attempt in range(max_retries):
-                try:
-                    # Upload file (rag_doc is RAGDocument in auto chunking mode)
-                    file_obj = BytesIO(rag_doc.content.encode("utf-8"))  # type: ignore[union-attr]
-                    file_obj.name = f"{doc_uuid}.txt"
-
-                    uploaded_file = await client.files.create(
-                        file=file_obj,
-                        purpose="assistants",
+            success, error = await self._upload_single_file_with_retry(
+                client, vector_store, rag_doc, chunking_strategy
+            )
+            if success:
+                successful += 1
+                if (idx + 1) % 10 == 0 or (idx + 1) == total_docs:
+                    LOG.info(
+                        "Progress: %d/%d files processed", idx + 1, total_docs
                     )
-
-                    # Attach file to vector store and wait for processing
-                    attributes = {
-                        **rag_doc.metadata,  # type: ignore[union-attr]
-                        "document_id": doc_uuid,
-                    }
-                    vs_file = await client.vector_stores.files.create(
-                        vector_store_id=vector_store.id,
-                        file_id=uploaded_file.id,
-                        attributes=attributes,
-                        chunking_strategy=chunking_strategy,
-                    )
-
-                    # Wait for this file to be processed
-                    max_wait = 5 * 60
-                    start_time = time.time()
-                    while (time.time() - start_time) < max_wait:
-                        vs_file = await client.vector_stores.files.retrieve(
-                            vector_store_id=vector_store.id,
-                            file_id=uploaded_file.id,
-                        )
-                        if vs_file.status in ("completed", "failed", "cancelled"):
-                            break
-                        await asyncio.sleep(0.5)
-
-                    if vs_file.status == "completed":
-                        successful += 1
-                        if (idx + 1) % 10 == 0 or (idx + 1) == total_docs:
-                            LOG.info(
-                                "Progress: %d/%d files processed",
-                                idx + 1,
-                                total_docs,
-                            )
-                        break
-
-                    error = getattr(vs_file, "last_error", "unknown error")
-                    LOG.warning(
-                        "File %s attempt %d/%d failed: %s",
-                        doc_uuid,
-                        attempt + 1,
-                        max_retries,
-                        error,
-                    )
-                    if attempt == max_retries - 1:
-                        failed_docs.append((doc_uuid, error))
-
-                except Exception as e:  # pylint: disable=broad-exception-caught
-                    LOG.warning(
-                        "File %s attempt %d/%d error: %s",
-                        doc_uuid,
-                        attempt + 1,
-                        max_retries,
-                        e,
-                    )
-                    if attempt == max_retries - 1:
-                        failed_docs.append((doc_uuid, str(e)))
-                    else:
-                        await asyncio.sleep(1)
+            else:
+                failed_docs.append((rag_doc.document_id, error))  # type: ignore[union-attr]
 
         LOG.info(
             "File processing finished: successful=%d/%d, failed=%d",
@@ -711,6 +740,49 @@ class DocumentProcessor:
             f"Unknown vector store type: {self.config.vector_store_type}"
         )
 
+    @staticmethod
+    def _partition_ignored(
+        docs: list[Any], ignore_list: Optional[list[str]]
+    ) -> tuple[list[Any], list[Any]]:
+        """Split docs into (docs_to_check, ignored_docs) based on title membership."""
+        if not ignore_list:
+            return docs, []
+
+        docs_to_check = []
+        ignored_docs = []
+        for doc in docs:
+            if (doc.metadata or {}).get("title") in ignore_list:
+                ignored_docs.append(doc)
+            else:
+                docs_to_check.append(doc)
+        return docs_to_check, ignored_docs
+
+    @staticmethod
+    def _apply_unreachable_action(
+        docs: list[Any],
+        docs_to_check: list[Any],
+        ignored_docs: list[Any],
+        unreachable_action: Optional[str],
+    ) -> list[Any]:
+        """Apply the unreachable_action policy, returning the docs to persist."""
+        # The `or {}` only guards metadata being None (S2259); a missing
+        # url_reachable key still raises KeyError so a broken metadata
+        # pipeline fails loudly instead of silently dropping docs.
+        reachable_docs = [
+            doc
+            for doc in docs_to_check
+            if (doc.metadata or {})["url_reachable"] is True
+        ]
+
+        if len(docs_to_check) == len(reachable_docs):
+            return docs
+
+        if unreachable_action == "fail":
+            raise RuntimeError("Some documents have unreachable URLs. ")
+        if unreachable_action == "drop":
+            return reachable_docs + ignored_docs
+        return docs
+
     def process(
         self,
         docs_dir: Path,
@@ -746,36 +818,10 @@ class DocumentProcessor:
 
         # Check for unreachable URLs if we are not ignoring them
         if unreachable_action != "warn":
-            # Separate docs into those we should check and those in ignore_list
-            if ignore_list:
-                docs_to_check = []
-                ignored_docs = []
-                for doc in docs:
-                    if (doc.metadata or {}).get("title") in ignore_list:
-                        ignored_docs.append(doc)
-                    else:
-                        docs_to_check.append(doc)
-            else:
-                docs_to_check = docs
-                ignored_docs = []
-
-            # Find reachable docs among those we're checking. The `or {}`
-            # only guards metadata being None (S2259); a missing
-            # url_reachable key still raises KeyError so a broken metadata
-            # pipeline fails loudly instead of silently dropping docs.
-            reachable_docs = [
-                doc
-                for doc in docs_to_check
-                if (doc.metadata or {})["url_reachable"] is True
-            ]
-
-            if len(docs_to_check) != len(reachable_docs):
-                # Optionally fail on unreachable URLs
-                if unreachable_action == "fail":
-                    raise RuntimeError("Some documents have unreachable URLs. ")
-                # Optionally drop unreachable URLs (but keep ignored docs)
-                if unreachable_action == "drop":
-                    docs = reachable_docs + ignored_docs
+            docs_to_check, ignored_docs = self._partition_ignored(docs, ignore_list)
+            docs = self._apply_unreachable_action(
+                docs, docs_to_check, ignored_docs, unreachable_action
+            )
 
         self.db.add_docs(docs)
 

--- a/tests/tests/test_document_processor_llama_stack.py
+++ b/tests/tests/test_document_processor_llama_stack.py
@@ -482,8 +482,9 @@ registered_resources:
             new=AsyncMock(side_effect=[(True, None), (False, "boom")]),
         )
 
+        coro = doc._upload_and_process_files(client, "test-index")
         with pytest.raises(RuntimeError, match="Failed to process 1/2 files"):
-            asyncio.run(doc._upload_and_process_files(client, "test-index"))
+            asyncio.run(coro)
 
     def _test_save(self, mocker, config):
         """Helper function to set up and verify save functionality."""

--- a/tests/tests/test_document_processor_llama_stack.py
+++ b/tests/tests/test_document_processor_llama_stack.py
@@ -408,6 +408,83 @@ registered_resources:
         )
         assert doc.documents == fake_out_docs
 
+    def test_upload_single_file_with_retry_succeeds_after_transient_failure(
+        self, mocker, llama_stack_processor
+    ):
+        """A failed attempt is retried and a later success returns (True, None)."""
+        import asyncio
+
+        doc = document_processor._LlamaStackDB(llama_stack_processor["config"])
+        client = mocker.Mock()
+        client.files.create = AsyncMock(return_value=mocker.Mock(id="file_1"))
+        client.vector_stores.files.create = AsyncMock()
+
+        failed = mocker.Mock(status="failed", last_error="boom")
+        completed = mocker.Mock(status="completed")
+        mocker.patch.object(
+            doc,
+            "_wait_for_file_processing",
+            new=AsyncMock(side_effect=[failed, completed]),
+        )
+
+        rag_doc = mocker.Mock(document_id="doc1", content="hello", metadata={})
+        success, error = asyncio.run(
+            doc._upload_single_file_with_retry(
+                client, mocker.Mock(id="vs_1"), rag_doc, {}
+            )
+        )
+
+        assert success is True
+        assert error is None
+        assert client.files.create.await_count == 2
+
+    def test_upload_single_file_with_retry_exhausts_retries(
+        self, mocker, llama_stack_processor
+    ):
+        """Every attempt raising returns (False, error) after max_retries."""
+        import asyncio
+
+        doc = document_processor._LlamaStackDB(llama_stack_processor["config"])
+        client = mocker.Mock()
+        client.files.create = AsyncMock(side_effect=RuntimeError("network down"))
+        sleep_mock = mocker.patch(
+            "aap_rag_content.document_processor.asyncio.sleep", new=AsyncMock()
+        )
+
+        rag_doc = mocker.Mock(document_id="doc1", content="hello", metadata={})
+        success, error = asyncio.run(
+            doc._upload_single_file_with_retry(
+                client, mocker.Mock(id="vs_1"), rag_doc, {}, max_retries=3
+            )
+        )
+
+        assert success is False
+        assert error == "network down"
+        assert client.files.create.await_count == 3
+        assert sleep_mock.await_count == 2  # slept between attempts, not after the last
+
+    def test_upload_and_process_files_raises_when_docs_fail(
+        self, mocker, llama_stack_processor
+    ):
+        """_upload_and_process_files raises RuntimeError when any doc fails all retries."""
+        import asyncio
+
+        doc = document_processor._LlamaStackDB(llama_stack_processor["config"])
+        client = mocker.Mock()
+        client.vector_stores.create = AsyncMock(return_value=mocker.Mock(id="vs_1"))
+        doc.documents = [
+            mocker.Mock(document_id="doc1", content="a", metadata={}),
+            mocker.Mock(document_id="doc2", content="b", metadata={}),
+        ]
+        mocker.patch.object(
+            doc,
+            "_upload_single_file_with_retry",
+            new=AsyncMock(side_effect=[(True, None), (False, "boom")]),
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to process 1/2 files"):
+            asyncio.run(doc._upload_and_process_files(client, "test-index"))
+
     def _test_save(self, mocker, config):
         """Helper function to set up and verify save functionality."""
         doc = document_processor._LlamaStackDB(config)


### PR DESCRIPTION
## What
Extracts helper functions to bring 3 of the 6 open `python:S3776` cognitive-complexity
findings under the 15 threshold:
- `document_processor._upload_and_process_files()`: 32 -> extracted
  `_wait_for_file_processing()` and `_upload_single_file_with_retry()`
- `document_processor.process()`: 20 -> extracted `_partition_ignored()` and
  `_apply_unreachable_action()`
- `mimir-parser.main()`: 34 -> extracted `_decrypt_and_extract_archive()`,
  `_generate_toc_files()`, `_extract_kb_articles()`, `_cleanup_html_files()`,
  `_process_mimir_archive()`

Pure extraction, no logic changes.

## Not included
The two `embeddings_model/train_script.py` findings (complexity 53 and 20) are
deliberately **not** touched here. That file imports `torch_xla` (TPU-only, not
installed in this or any normal dev/CI environment — which is why
`embeddings_model/` is excluded from the coverage config) and separately fails
to import against the currently-pinned `transformers` version (`AdamW` was
removed from that package). Both are pre-existing, unrelated to this PR. Getting
verifiable characterization tests running would mean stubbing `torch_xla` and
patching around the `AdamW` break just to reach the code — the resulting safety
net would be more synthetic than real. Left as backlog; worth a dedicated look
at whether this script still needs to work at all.

## Why
Continuation of #408 (SonarCloud gate cleanup) — see that PR for the full
`new_security_rating`/`new_violations` gate background.

## Scope
`document_processor.process()`'s `unreachable_action="fail"`/`"drop"` and
`ignore_list` branches had no prior test coverage (only the default `"warn"`
path was tested) -- added 5 characterization tests confirming current behavior
against the unrefactored code first, then re-ran green after extracting.
`mimir-parser.main()` is `pragma: no-cover` CLI orchestration with no existing
harness; verified via syntax check, `ruff --select F` (no undefined names), and
the rest of `test_mimir_parser.py` staying green. `make unit-test`: 120 passed,
8 skipped (baseline + 5 new), both before and after each refactor commit.