### PR TITLE
Bump llama-stack for 1 CVE(s)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev = [
     "faiss-cpu==1.12",
     "filelock==3.32.2",
     "llama-stack-client==0.4.3",
-    "llama-stack==0.4.3",
+    "llama-stack==0.4.4",
     "llama-stack-api==0.4.4",  # Must match llama-stack version
     "mypy",
     "pillow==12.3.0", # Transient dep pinned to handle CVE (CVE-2026-40192, CVE-2026-59197, CVE-2026-54058, CVE-2026-54060, CVE-2026-55380, CVE-2026-55379)

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ dev = [
     { name = "cryptography", specifier = ">=50.0.0,<51" },
     { name = "faiss-cpu", specifier = "==1.12" },
     { name = "filelock", specifier = "==3.32.2" },
-    { name = "llama-stack", specifier = "==0.4.3" },
+    { name = "llama-stack", specifier = "==0.4.4" },
     { name = "llama-stack-api", specifier = "==0.4.4" },
     { name = "llama-stack-client", specifier = "==0.4.3" },
     { name = "mypy" },
@@ -733,7 +733,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack"
-version = "0.4.3"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -766,9 +766,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/f8/b46c825c7d4050524ca4da9ff7f2622b101044f65cf50f708cf5b6ac935d/llama_stack-0.4.3.tar.gz", hash = "sha256:70d379ae9dbb5b1d0693f14054d9817aba183ffcd805133f0a4442baee132c6d", size = 3357773, upload-time = "2026-01-26T21:46:01.588Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/bc/c21785662c86e9e82cda444c2f5bf0e263c3969a35a60e377c5c189743e1/llama_stack-0.4.4.tar.gz", hash = "sha256:37c40ed43230388c8afa306c02f4f4e72e401dc5ef5dd851d1c27c6a27074aa8", size = 16063161, upload-time = "2026-01-30T16:29:20.693Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/eb/a4c6c6e6391e13b7d71a116df847b13c334355e9ec18441635140b8fbe1f/llama_stack-0.4.3-py3-none-any.whl", hash = "sha256:423207eae2b640894992a9075ff9dd6300ff904ab06a49fe38cfe0bb809d4669", size = 3695786, upload-time = "2026-01-26T21:45:59.607Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ea/75fd97a70ae6c81c11692d198e627233cb7bfa3c158fb8780433c239738b/llama_stack-0.4.4-py3-none-any.whl", hash = "sha256:0778fb5a93fb4fb2ff5f31d65e84034b7e2f27bc2298b39ba107127872ec7c1b", size = 4529634, upload-time = "2026-01-30T16:29:18.227Z" },
 ]
 
 [[package]]
@@ -1766,13 +1766,13 @@ resolution-markers = [
     "sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "sympy", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
@@ -1788,13 +1788,13 @@ resolution-markers = [
     "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", marker = "sys_platform != 'darwin'" },
+    { name = "setuptools", marker = "sys_platform != 'darwin'" },
+    { name = "sympy", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:ffadde149901c8afa138daa38d898264003cfcf1a3336ca5cd964b5af227d867", upload-time = "2026-07-08T19:28:41Z" },


### PR DESCRIPTION
## Summary

Dependency bumps to address 1 known CVE(s):


- `llama-stack` 0.4.3 → 0.4.4 (PYSEC-2026-1572)




## Test plan
- [ ] CI passes
- [ ] `uv lock --check` / `uv pip compile` resolves successfully